### PR TITLE
Fix Crates.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/klingtnet/rosc.svg?branch=master)](https://travis-ci.org/klingtnet/rosc)
 ![license](https://img.shields.io/badge/license-MIT%2FApache%202.0-blue.svg)
-[![Crates.io](https://img.shields.io/crates/v/rustc-serialize.svg)](https://crates.io/crates/rosc) [![rustdoc](https://img.shields.io/badge/rustdoc-hosted-blue.svg)](https://docs.klingt.net/rustdoc/rosc)
+[![Crates.io](https://img.shields.io/crates/v/rosc.svg)](https://crates.io/crates/rosc) [![rustdoc](https://img.shields.io/badge/rustdoc-hosted-blue.svg)](https://docs.klingt.net/rustdoc/rosc)
 
 **rosc** is an implementation of the [OSC 1.0](http://opensoundcontrol.org/spec-1_0) protocol in pure Rust.
 


### PR DESCRIPTION
It was pointing to the wrong project