### PR TITLE
Add OscArray type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target/
 *.rs.bk
 *.rlib
 *.swp
+/.idea/
+/target-install/
+/Makefile

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosc"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Andreas Linz <klingt.net@gmail.com>"]
 description = "An OSC library for Rust"
 keywords = ["audio", "osc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ readme = "README.md"
 lints = ["clippy"]
 
 [dependencies]
-byteorder = "0.5"
+byteorder = "1"
 clippy = {version="^0", optional=true}

--- a/examples/receiver.rs
+++ b/examples/receiver.rs
@@ -49,6 +49,6 @@ fn handle_packet(packet: OscPacket) {
         }
         OscPacket::Bundle(bundle) => {
             println!("OSC Bundle: {:?}", bundle);
-        },
+        }
     }
 }

--- a/examples/sender.rs
+++ b/examples/sender.rs
@@ -13,8 +13,10 @@ fn get_addr_from_arg(arg: &str) -> SocketAddrV4 {
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    let usage = format!("Usage: {} HOST_IP:HOST_PORT CLIENT_IP:CLIENT_PORT",
-                        &args[0]);
+    let usage = format!(
+        "Usage: {} HOST_IP:HOST_PORT CLIENT_IP:CLIENT_PORT",
+        &args[0]
+    );
     if args.len() < 3 {
         panic!(usage);
     }
@@ -24,10 +26,9 @@ fn main() {
 
     // switch view
     let msg_buf = encoder::encode(&OscPacket::Message(OscMessage {
-                      addr: "/3".to_string(),
-                      args: None,
-                  }))
-                      .unwrap();
+        addr: "/3".to_string(),
+        args: None,
+    })).unwrap();
 
     sock.send_to(&msg_buf, to_addr).unwrap();
 
@@ -38,17 +39,15 @@ fn main() {
         let x = 0.5 + (step_size * (i % steps) as f32).sin() / 2.0;
         let y = 0.5 + (step_size * (i % steps) as f32).cos() / 2.0;
         let mut msg_buf = encoder::encode(&OscPacket::Message(OscMessage {
-                              addr: "/3/xy1".to_string(),
-                              args: Some(vec![OscType::Float(x), OscType::Float(y)]),
-                          }))
-                              .unwrap();
+            addr: "/3/xy1".to_string(),
+            args: Some(vec![OscType::Float(x), OscType::Float(y)]),
+        })).unwrap();
 
         sock.send_to(&msg_buf, to_addr).unwrap();
         msg_buf = encoder::encode(&OscPacket::Message(OscMessage {
-                      addr: "/3/xy2".to_string(),
-                      args: Some(vec![OscType::Float(y), OscType::Float(x)]),
-                  }))
-                      .unwrap();
+            addr: "/3/xy2".to_string(),
+            args: Some(vec![OscType::Float(y), OscType::Float(x)]),
+        })).unwrap();
         sock.send_to(&msg_buf, to_addr).unwrap();
         thread::sleep(Duration::from_millis(20));
     }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,6 +1,6 @@
-use types::{OscPacket, OscType, Result, OscMessage, OscMidiMessage, OscColor, OscBundle};
-use errors::OscError;
 use encoder;
+use errors::OscError;
+use types::{OscArray, OscBundle, OscColor, OscMessage, OscMidiMessage, OscPacket, OscType, Result};
 
 use std::{io, char};
 use std::io::{Read, BufRead};
@@ -129,7 +129,7 @@ fn read_osc_args(cursor: &mut io::Cursor<&[u8]>, raw_type_tags: String) -> Resul
         } else if tag == ']' {
             // found the end of the current array:
             // create array object from current frame and step one level up
-            let array = OscType::Array(args);
+            let array = OscType::Array(OscArray { content: args });
             match stack.pop() {
                 Some(stashed) => args = stashed,
                 None => return Err(OscError::BadMessage("Encountered ] outside array")),

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -51,7 +51,9 @@ fn decode_bundle(msg: &[u8]) -> Result<OscPacket> {
 
     let bundle_tag = read_osc_string(&mut cursor)?;
     if bundle_tag != "#bundle" {
-        return Err(OscError::BadBundle(format!("Wrong bundle specifier: {}", bundle_tag)));
+        return Err(OscError::BadBundle(
+            format!("Wrong bundle specifier: {}", bundle_tag),
+        ));
     }
 
     let time_tag = read_time_tag(&mut cursor)?;
@@ -78,7 +80,8 @@ fn decode_bundle(msg: &[u8]) -> Result<OscPacket> {
 }
 
 fn read_bundle_element_size(cursor: &mut io::Cursor<&[u8]>) -> Result<usize> {
-    cursor.read_u32::<BigEndian>()
+    cursor
+        .read_u32::<BigEndian>()
         .map(|size| size as usize)
         .map_err(OscError::ReadError)
 }
@@ -93,28 +96,27 @@ fn read_bundle_element(cursor: &mut io::Cursor<&[u8]>, elem_size: usize) -> Resu
     if cnt == elem_size {
         decode(&buf)
     } else {
-        Err(OscError::BadBundle("Bundle shorter than expected!".to_string()))
+        Err(OscError::BadBundle(
+            "Bundle shorter than expected!".to_string(),
+        ))
     }
 }
 
 fn read_osc_string(cursor: &mut io::Cursor<&[u8]>) -> Result<String> {
     let mut str_buf: Vec<u8> = Vec::new();
     // ignore returned byte count
-    cursor.read_until(0, &mut str_buf).map_err(OscError::ReadError)?;
+    cursor.read_until(0, &mut str_buf).map_err(
+        OscError::ReadError,
+    )?;
     pad_cursor(cursor);
     // convert to String and remove nul bytes
     String::from_utf8(str_buf)
         .map_err(OscError::StringError)
-        .map(|s| {
-            s.trim_matches(0u8 as char)
-                .to_string()
-        })
+        .map(|s| s.trim_matches(0u8 as char).to_string())
 }
 
 fn read_osc_args(cursor: &mut io::Cursor<&[u8]>, raw_type_tags: String) -> Result<Vec<OscType>> {
-    let type_tags: Vec<char> = raw_type_tags.chars()
-        .skip(1)
-        .collect();
+    let type_tags: Vec<char> = raw_type_tags.chars().skip(1).collect();
 
     let mut args: Vec<OscType> = Vec::with_capacity(type_tags.len());
     for tag in type_tags {
@@ -127,24 +129,25 @@ fn read_osc_args(cursor: &mut io::Cursor<&[u8]>, raw_type_tags: String) -> Resul
 fn read_osc_arg(cursor: &mut io::Cursor<&[u8]>, tag: char) -> Result<OscType> {
     match tag {
         'f' => {
-            cursor.read_f32::<BigEndian>()
-                .map(OscType::Float)
-                .map_err(OscError::ReadError)
+            cursor.read_f32::<BigEndian>().map(OscType::Float).map_err(
+                OscError::ReadError,
+            )
         }
         'd' => {
-            cursor.read_f64::<BigEndian>()
+            cursor
+                .read_f64::<BigEndian>()
                 .map(OscType::Double)
                 .map_err(OscError::ReadError)
         }
         'i' => {
-            cursor.read_i32::<BigEndian>()
-                .map(OscType::Int)
-                .map_err(OscError::ReadError)
+            cursor.read_i32::<BigEndian>().map(OscType::Int).map_err(
+                OscError::ReadError,
+            )
         }
         'h' => {
-            cursor.read_i64::<BigEndian>()
-                .map(OscType::Long)
-                .map_err(OscError::ReadError)
+            cursor.read_i64::<BigEndian>().map(OscType::Long).map_err(
+                OscError::ReadError,
+            )
         }
         's' => read_osc_string(cursor).map(OscType::String),
         't' => read_time_tag(cursor),
@@ -156,14 +159,16 @@ fn read_osc_arg(cursor: &mut io::Cursor<&[u8]>, tag: char) -> Result<OscType> {
         'I' => Ok(OscType::Inf),
         'c' => read_char(cursor),
         'm' => read_midi_message(cursor),
-        _ => Err(OscError::BadArg(format!("Type tag \"{}\" is not implemented!", tag))),
+        _ => Err(OscError::BadArg(
+            format!("Type tag \"{}\" is not implemented!", tag),
+        )),
     }
 }
 
 fn read_char(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
-    let opt_char = cursor.read_u32::<BigEndian>()
-        .map(char::from_u32)
-        .map_err(OscError::ReadError)?;
+    let opt_char = cursor.read_u32::<BigEndian>().map(char::from_u32).map_err(
+        OscError::ReadError,
+    )?;
     match opt_char {
         Some(c) => Ok(OscType::Char(c)),
         None => Err(OscError::BadArg("Argument is not a char!".to_string())),
@@ -171,11 +176,11 @@ fn read_char(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
 }
 
 fn read_blob(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
-    let size: usize = cursor.read_u32::<BigEndian>()
-        .map_err(OscError::ReadError)? as usize;
+    let size: usize = cursor.read_u32::<BigEndian>().map_err(OscError::ReadError)? as usize;
     let mut byte_buf: Vec<u8> = Vec::with_capacity(size);
 
-    cursor.take(size as u64)
+    cursor
+        .take(size as u64)
         .read_to_end(&mut byte_buf)
         .map_err(OscError::ReadError)?;
 
@@ -185,17 +190,17 @@ fn read_blob(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
 }
 
 fn read_time_tag(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
-    let date = cursor.read_u32::<BigEndian>()
-        .map_err(OscError::ReadError)?;
-    let frac = cursor.read_u32::<BigEndian>()
-        .map_err(OscError::ReadError)?;
+    let date = cursor.read_u32::<BigEndian>().map_err(OscError::ReadError)?;
+    let frac = cursor.read_u32::<BigEndian>().map_err(OscError::ReadError)?;
 
     Ok(OscType::Time(date, frac))
 }
 
 fn read_midi_message(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
     let mut buf: Vec<u8> = Vec::with_capacity(4);
-    cursor.take(4).read_to_end(&mut buf).map_err(OscError::ReadError)?;
+    cursor.take(4).read_to_end(&mut buf).map_err(
+        OscError::ReadError,
+    )?;
 
     Ok(OscType::Midi(OscMidiMessage {
         port: buf[0],
@@ -208,7 +213,9 @@ fn read_midi_message(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
 
 fn read_osc_color(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
     let mut buf: Vec<u8> = Vec::with_capacity(4);
-    cursor.take(4).read_to_end(&mut buf).map_err(OscError::ReadError)?;
+    cursor.take(4).read_to_end(&mut buf).map_err(
+        OscError::ReadError,
+    )?;
 
     Ok(OscType::Color(OscColor {
         red: buf[0],

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -144,7 +144,7 @@ fn encode_arg(arg: &OscType) -> Result<(Option<Vec<u8>>, String)> {
         OscType::Array(ref x) => {
             let mut bytes = vec![0u8; 0];
             let mut type_tags = String::from("[");
-            for v in x.iter() {
+            for v in x.content.iter() {
                 match encode_arg(v) {
                     Ok((Some(other_bytes), other_type_tags)) => {
                         bytes.extend(other_bytes);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -45,8 +45,7 @@ fn encode_message(msg: &OscMessage) -> Result<Vec<u8>> {
         }
     }
 
-    msg_bytes.extend(encode_string(type_tags.into_iter()
-        .collect::<String>()));
+    msg_bytes.extend(encode_string(type_tags.into_iter().collect::<String>()));
     if !arg_bytes.is_empty() {
         msg_bytes.extend(arg_bytes);
     }
@@ -133,13 +132,7 @@ fn encode_arg(arg: &OscType) -> Result<(Option<Vec<u8>>, char)> {
         OscType::Time(ref x, ref y) => Ok((Some(encode_time_tag(*x, *y)), 't')),
         OscType::Midi(ref x) => Ok((Some(vec![x.port, x.status, x.data1, x.data2]), 'm')),
         OscType::Color(ref x) => Ok((Some(vec![x.red, x.green, x.blue, x.alpha]), 'r')),
-        OscType::Bool(ref x) => {
-            if *x {
-                Ok((None, 'T'))
-            } else {
-                Ok((None, 'F'))
-            }
-        }
+        OscType::Bool(ref x) => if *x { Ok((None, 'T')) } else { Ok((None, 'F')) },
         OscType::Nil => Ok((None, 'N')),
         OscType::Inf => Ok((None, 'I')),
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -130,7 +130,7 @@ fn encode_arg(arg: &OscType) -> Result<(Option<Vec<u8>>, String)> {
             Ok((Some(bytes), "b".into()))
         }
         OscType::Time(ref x, ref y) => Ok((Some(encode_time_tag(*x, *y)), "t".into())),
-        OscType::Midi(ref x) => Ok((Some(vec![x.port, x.status, x.data1, x.data2]), "m'".into())),
+        OscType::Midi(ref x) => Ok((Some(vec![x.port, x.status, x.data1, x.data2]), "m".into())),
         OscType::Color(ref x) => Ok((Some(vec![x.red, x.green, x.blue, x.alpha]), "r".into())),
         OscType::Bool(ref x) => {
             if *x {

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,7 +3,7 @@ use std::result;
 
 /// see OSC Type Tag String: [OSC Spec. 1.0](http://opensoundcontrol.org/spec-1_0)
 /// padding: zero bytes (n*4)
-#[derive(Clone,Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum OscType {
     Int(i32),
     Float(f32),
@@ -68,7 +68,7 @@ impl OscType {
 }
 /// Represents the parts of a Midi message. Mainly used for
 /// tunneling midi over a network using the OSC protocol.
-#[derive(Clone,Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OscMidiMessage {
     pub port: u8,
     pub status: u8,
@@ -78,7 +78,7 @@ pub struct OscMidiMessage {
 
 /// An *osc packet* can contain an *osc message* or a bundle of nested messages
 /// which is called *osc bundle*.
-#[derive(Clone,Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum OscPacket {
     Message(OscMessage),
     Bundle(OscBundle),
@@ -90,7 +90,7 @@ pub enum OscPacket {
 /// you want to control with OSC) and the arguments
 /// are used to set properties of the element to the
 /// respective values.
-#[derive(Clone,Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OscMessage {
     pub addr: String,
     pub args: Option<Vec<OscType>>,
@@ -99,14 +99,14 @@ pub struct OscMessage {
 /// An OSC bundle contains zero or more OSC packets
 /// and a time tag. The contained packets *should* be
 /// applied at the given time tag.
-#[derive(Clone,Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OscBundle {
     pub timetag: OscType,
     pub content: Vec<OscPacket>,
 }
 
 /// An RGBA color.
-#[derive(Clone,Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OscColor {
     pub red: u8,
     pub green: u8,
@@ -120,7 +120,7 @@ impl From<String> for OscMessage {
     fn from(s: String) -> OscMessage {
         OscMessage {
             addr: s,
-            args: None
+            args: None,
         }
     }
 }
@@ -128,7 +128,7 @@ impl<'a> From<&'a str> for OscMessage {
     fn from(s: &str) -> OscMessage {
         OscMessage {
             addr: s.to_string(),
-            args: None
+            args: None,
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,7 +17,7 @@ pub enum OscType {
     Color(OscColor),
     Midi(OscMidiMessage),
     Bool(bool),
-    Array(Vec<OscType>),
+    Array(OscArray),
     Nil,
     Inf,
 }
@@ -46,7 +46,7 @@ value_impl! {
     (float, Float, f32),
     (string, String, String),
     (blob, Blob, Vec<u8>),
-    (array, Array, Vec<OscType>),
+    (array, Array, OscArray),
     (long, Long, i64),
     (double, Double, f64),
     (char, Char, char),
@@ -119,6 +119,12 @@ pub struct OscColor {
     pub green: u8,
     pub blue: u8,
     pub alpha: u8,
+}
+
+/// An OscArray color.
+#[derive(Clone, Debug, PartialEq)]
+pub struct OscArray {
+    pub content: Vec<OscType>,
 }
 
 pub type Result<T> = result::Result<T, errors::OscError>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,6 +17,7 @@ pub enum OscType {
     Color(OscColor),
     Midi(OscMidiMessage),
     Bool(bool),
+    Array(Vec<OscType>),
     Nil,
     Inf,
 }
@@ -45,6 +46,7 @@ value_impl! {
     (float, Float, f32),
     (string, String, String),
     (blob, Blob, Vec<u8>),
+    (array, Array, Vec<OscType>),
     (long, Long, i64),
     (double, Double, f64),
     (char, Char, char),

--- a/tests/decoder_test.rs
+++ b/tests/decoder_test.rs
@@ -3,7 +3,6 @@ extern crate byteorder;
 
 use byteorder::{ByteOrder, BigEndian};
 use std::mem;
-use std::ascii::AsciiExt;
 
 use rosc::{decoder, encoder};
 

--- a/tests/decoder_test.rs
+++ b/tests/decoder_test.rs
@@ -4,7 +4,7 @@ extern crate rosc;
 use byteorder::{BigEndian, ByteOrder};
 use std::mem;
 
-use rosc::{decoder, encoder};
+use rosc::{decoder, encoder, OscType};
 
 #[test]
 fn test_decode_no_args() {
@@ -58,7 +58,9 @@ fn test_decode_args() {
     let c = '$';
     let c_bytes: [u8; 4] = unsafe { mem::transmute((c as u32).to_be()) };
 
-    let type_tags = encoder::encode_string(",fdsTFibhNIc");
+    let a = vec![OscType::Int(i), OscType::Float(f), OscType::Int(i)];
+
+    let type_tags = encoder::encode_string(",fdsTFibhNIc[ifi]");
 
     let args: Vec<u8> = f_bytes
         .iter()
@@ -70,6 +72,10 @@ fn test_decode_args() {
         .chain(vec![0u8, 0u8].iter())
         .chain(h_bytes.iter())
         .chain(c_bytes.iter())
+        // array content
+        .chain(i_bytes.iter())
+        .chain(f_bytes.iter())
+        .chain(i_bytes.iter())
         .map(|x| *x)
         .collect::<Vec<u8>>();
 
@@ -96,6 +102,7 @@ fn test_decode_args() {
                     rosc::OscType::Nil => (),
                     // test time-tags, midi-messages and chars
                     rosc::OscType::Char(x) => assert_eq!(c, x),
+                    rosc::OscType::Array(x) => assert_eq!(a, x.content),
                     _ => panic!(),
                 }
             }

--- a/tests/decoder_test.rs
+++ b/tests/decoder_test.rs
@@ -1,11 +1,10 @@
-extern crate rosc;
 extern crate byteorder;
+extern crate rosc;
 
-use byteorder::{ByteOrder, BigEndian};
+use byteorder::{BigEndian, ByteOrder};
 use std::mem;
 
 use rosc::{decoder, encoder};
-
 
 #[test]
 fn test_decode_no_args() {
@@ -13,9 +12,7 @@ fn test_decode_no_args() {
     let raw_addr = "/some/valid/address/4";
     let addr = encoder::encode_string(raw_addr);
     let type_tags = encoder::encode_string(",");
-    let merged: Vec<u8> = addr.into_iter()
-                              .chain(type_tags.into_iter())
-                              .collect();
+    let merged: Vec<u8> = addr.into_iter().chain(type_tags.into_iter()).collect();
     let osc_packet: Result<rosc::OscPacket, rosc::OscError> = decoder::decode(&merged);
     assert!(osc_packet.is_ok());
     match osc_packet {
@@ -63,22 +60,23 @@ fn test_decode_args() {
 
     let type_tags = encoder::encode_string(",fdsTFibhNIc");
 
-    let args: Vec<u8> = f_bytes.iter()
-                               .chain(d_bytes.iter())
-                               .chain(s_bytes.iter())
-                               .chain(i_bytes.iter())
-                               .chain(blob_size.iter())
-                               .chain(blob.iter())
-                               .chain(vec![0u8, 0u8].iter())
-                               .chain(h_bytes.iter())
-                               .chain(c_bytes.iter())
-                               .map(|x| *x)
-                               .collect::<Vec<u8>>();
+    let args: Vec<u8> = f_bytes
+        .iter()
+        .chain(d_bytes.iter())
+        .chain(s_bytes.iter())
+        .chain(i_bytes.iter())
+        .chain(blob_size.iter())
+        .chain(blob.iter())
+        .chain(vec![0u8, 0u8].iter())
+        .chain(h_bytes.iter())
+        .chain(c_bytes.iter())
+        .map(|x| *x)
+        .collect::<Vec<u8>>();
 
     let merged: Vec<u8> = addr.into_iter()
-                              .chain(type_tags.into_iter())
-                              .chain(args)
-                              .collect::<Vec<u8>>();
+        .chain(type_tags.into_iter())
+        .chain(args)
+        .collect::<Vec<u8>>();
 
     match decoder::decode(&merged).unwrap() {
         rosc::OscPacket::Message(msg) => {
@@ -100,7 +98,6 @@ fn test_decode_args() {
                     rosc::OscType::Char(x) => assert_eq!(c, x),
                     _ => panic!(),
                 }
-
             }
         }
         _ => panic!("Expected an OSC message!"),

--- a/tests/encoder_test.rs
+++ b/tests/encoder_test.rs
@@ -30,30 +30,32 @@ fn test_encode_message_wo_args() {
 fn test_encode_message_with_args() {
     let msg_packet = OscPacket::Message(OscMessage {
         addr: "/another/address/1".to_string(),
-        args: Some(vec![4i32.into(),
-                        42i64.into(),
-                        3.1415926f32.into(),
-                        3.14159265359f64.into(),
-                        "This is a string.".to_string().into(),
-                        vec![1u8, 2u8, 3u8].into(),
-                        (123, 456).into(),
-                        'c'.into(),
-                        false.into(),
-                        true.into(),
-                        OscType::Nil,
-                        OscType::Inf,
-                        OscMidiMessage {
-                            port: 4,
-                            status: 41,
-                            data1: 42,
-                            data2: 129,
-                        }.into(),
-                        OscColor {
-                            red: 255,
-                            green: 192,
-                            blue: 42,
-                            alpha: 13,
-                        }.into()]),
+        args: Some(vec![
+            4i32.into(),
+            42i64.into(),
+            3.1415926f32.into(),
+            3.14159265359f64.into(),
+            "This is a string.".to_string().into(),
+            vec![1u8, 2u8, 3u8].into(),
+            (123, 456).into(),
+            'c'.into(),
+            false.into(),
+            true.into(),
+            OscType::Nil,
+            OscType::Inf,
+            OscMidiMessage {
+                port: 4,
+                status: 41,
+                data1: 42,
+                data2: 129,
+            }.into(),
+            OscColor {
+                red: 255,
+                green: 192,
+                blue: 42,
+                alpha: 13,
+            }.into(),
+        ]),
     });
 
     let enc_msg = encoder::encode(&msg_packet).unwrap();
@@ -101,9 +103,11 @@ fn test_encode_bundle() {
 
     let root_bundle = OscPacket::Bundle(OscBundle {
         timetag: (1234, 4321).into(),
-        content: vec![OscPacket::Message(msg0),
-                      OscPacket::Message(msg1),
-                      OscPacket::Bundle(bundle1)],
+        content: vec![
+            OscPacket::Message(msg0),
+            OscPacket::Message(msg1),
+            OscPacket::Bundle(bundle1),
+        ],
     });
 
     let enc_bundle = encoder::encode(&root_bundle).unwrap();

--- a/tests/encoder_test.rs
+++ b/tests/encoder_test.rs
@@ -1,7 +1,7 @@
 extern crate rosc;
 
-use rosc::{encoder, decoder};
-use rosc::{OscMessage, OscMidiMessage, OscColor, OscPacket, OscType, OscBundle};
+use rosc::{decoder, encoder};
+use rosc::{OscArray, OscBundle, OscColor, OscMessage, OscMidiMessage, OscPacket, OscType};
 
 #[test]
 fn test_encode_message_wo_args() {
@@ -55,6 +55,16 @@ fn test_encode_message_with_args() {
                 green: 192,
                 blue: 42,
                 alpha: 13,
+            }
+            .into(),
+            OscArray {
+                content: vec![
+                    42i32.into(),
+                OscArray{
+                    content: vec![1.23.into(), 3.21.into()]
+                }.into(),
+                "Yay".into()
+                ]
             }.into(),
         ]),
     });


### PR DESCRIPTION
Complete implementation for OSC array types. Arrays in this implementation may contain elements with different types, and all types are supported. This includes other arrays, which can be nested as needed.

~~Experimental encoding implementation for OSC array types to see how this could look like. I'm sure there's still room for improvement, so it's a draft for now.~~