### PR TITLE
Add OscTime type alias and use it for OscBundle time tags

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -158,7 +158,7 @@ fn read_osc_arg(cursor: &mut io::Cursor<&[u8]>, tag: char) -> Result<OscType> {
             .map(OscType::Long)
             .map_err(OscError::ReadError),
         's' => read_osc_string(cursor).map(OscType::String),
-        't' => read_time_tag(cursor),
+        't' => read_time_tag(cursor).map(OscType::Time),
         'b' => read_blob(cursor),
         'r' => read_osc_color(cursor),
         'T' => Ok(true.into()),
@@ -201,7 +201,7 @@ fn read_blob(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
     Ok(OscType::Blob(byte_buf))
 }
 
-fn read_time_tag(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
+fn read_time_tag(cursor: &mut io::Cursor<&[u8]>) -> Result<(u32, u32)> {
     let date = cursor
         .read_u32::<BigEndian>()
         .map_err(OscError::ReadError)?;
@@ -209,7 +209,7 @@ fn read_time_tag(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
         .read_u32::<BigEndian>()
         .map_err(OscError::ReadError)?;
 
-    Ok(OscType::Time(date, frac))
+    Ok((date, frac))
 }
 
 fn read_midi_message(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -54,7 +54,7 @@ fn encode_bundle(bundle: &OscBundle) -> Result<Vec<u8>> {
     let mut bundle_bytes: Vec<u8> = Vec::new();
     bundle_bytes.extend(encode_string("#bundle".to_string()).into_iter());
 
-    match encode_arg(&bundle.timetag)? {
+    match encode_arg(&OscType::Time(bundle.timetag))? {
         (Some(x), _) => {
             bundle_bytes.extend(x.into_iter());
         }
@@ -127,7 +127,7 @@ fn encode_arg(arg: &OscType) -> Result<(Option<Vec<u8>>, String)> {
             }
             Ok((Some(bytes), "b".into()))
         }
-        OscType::Time(ref x, ref y) => Ok((Some(encode_time_tag(*x, *y)), "t".into())),
+        OscType::Time((ref x, ref y)) => Ok((Some(encode_time_tag(*x, *y)), "t".into())),
         OscType::Midi(ref x) => Ok((Some(vec![x.port, x.status, x.data1, x.data2]), "m".into())),
         OscType::Color(ref x) => Ok((Some(vec![x.red, x.green, x.blue, x.alpha]), "r".into())),
         OscType::Bool(ref x) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,10 @@
 use crate::errors;
 use std::result;
 
+/// A time tag in OSC message consists of two 32-bit integers where the first one denotes the number of seconds since 1900-01-01 and the second the fractions of a second.
+/// For details on its semantics see http://opensoundcontrol.org/node/3/#timetags
+pub type OscTime = (u32, u32);
+
 /// see OSC Type Tag String: [OSC Spec. 1.0](http://opensoundcontrol.org/spec-1_0)
 /// padding: zero bytes (n*4)
 #[derive(Clone, Debug, PartialEq)]
@@ -10,7 +14,7 @@ pub enum OscType {
     String(String),
     Blob(Vec<u8>),
     // use struct for time tag to avoid destructuring
-    Time(u32, u32),
+    Time(OscTime),
     Long(i64),
     Double(f64),
     Char(char),
@@ -56,14 +60,14 @@ value_impl! {
 }
 impl From<(u32, u32)> for OscType {
     fn from(time: (u32, u32)) -> Self {
-        OscType::Time(time.0, time.1)
+        OscType::Time((time.0, time.1))
     }
 }
 impl OscType {
     #[allow(dead_code)]
     pub fn time(self) -> Option<(u32, u32)> {
         match self {
-            OscType::Time(sec, frac) => Some((sec, frac)),
+            OscType::Time((sec, frac)) => Some((sec, frac)),
             _ => None,
         }
     }
@@ -108,7 +112,7 @@ pub struct OscMessage {
 /// applied at the given time tag.
 #[derive(Clone, Debug, PartialEq)]
 pub struct OscBundle {
-    pub timetag: OscType,
+    pub timetag: OscTime,
     pub content: Vec<OscPacket>,
 }
 


### PR DESCRIPTION
Before the time tag of an OscBundle was of type OscType and such
required a user to match against this enum, which is cumbersome.

Closes #9