### PR TITLE
Support empty bundles

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -56,6 +56,14 @@ fn decode_bundle(msg: &[u8]) -> Result<OscPacket> {
 
     let mut bundle: Vec<OscPacket> = Vec::new();
 
+    // Empty bundle
+    if msg.len() == cursor.position() as usize {
+        return Ok(OscPacket::Bundle(OscBundle {
+            timetag: time_tag,
+            content: bundle,
+        }))
+    }
+
     let mut elem_size = read_bundle_element_size(&mut cursor)?;
 
     while msg.len() >= (cursor.position() as usize) + elem_size {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -64,8 +64,6 @@ fn encode_bundle(bundle: &OscBundle) -> Result<Vec<u8>> {
     }
 
     if bundle.content.is_empty() {
-        // TODO: A bundle of length zero, should this really be supported?
-        bundle_bytes.extend([0u8; 4].iter());
         return Ok(bundle_bytes);
     }
 

--- a/tests/decoder_test.rs
+++ b/tests/decoder_test.rs
@@ -4,7 +4,7 @@ extern crate rosc;
 use byteorder::{BigEndian, ByteOrder};
 use std::mem;
 
-use rosc::{decoder, encoder, OscType};
+use rosc::{decoder, encoder, OscBundle, OscPacket, OscType};
 
 #[test]
 fn test_decode_no_args() {
@@ -21,6 +21,22 @@ fn test_decode_no_args() {
             assert!(msg.args.is_empty());
         }
         Ok(_) => panic!("Expected an OscMessage!"),
+        Err(e) => panic!(e),
+    }
+}
+
+#[test]
+fn test_decode_empty_bundle() {
+    let timetag = (4, 2);
+    let content = vec![];
+    let packet = encoder::encode(&OscPacket::Bundle(OscBundle { timetag, content })).unwrap();
+    let osc_packet: Result<rosc::OscPacket, rosc::OscError> = decoder::decode(&packet);
+    match osc_packet {
+        Ok(rosc::OscPacket::Bundle(bundle)) => {
+            assert_eq!(timetag, bundle.timetag);
+            assert!(bundle.content.is_empty());
+        }
+        Ok(_) => panic!("Expected an OscBundle!"),
         Err(e) => panic!(e),
     }
 }

--- a/tests/encoder_test.rs
+++ b/tests/encoder_test.rs
@@ -27,6 +27,30 @@ fn test_encode_message_wo_args() {
 }
 
 #[test]
+fn test_encode_empty_bundle() {
+    let bundle_packet = OscPacket::Bundle(OscBundle {
+        timetag: (4, 2),
+        content: vec![],
+    });
+
+    let enc_bundle = encoder::encode(&bundle_packet).unwrap();
+    assert_eq!(enc_bundle.len() % 4, 0);
+    assert_eq!(enc_bundle.len(), 16);
+
+    let dec_bundle = match decoder::decode(&enc_bundle).unwrap() {
+        OscPacket::Bundle(m) => m,
+        _ => panic!("Expected OscBundle!"),
+    };
+
+    let bundle = match bundle_packet {
+        OscPacket::Bundle(ref bundle) => bundle,
+        _ => panic!(),
+    };
+
+    assert_eq!(*bundle, dec_bundle)
+}
+
+#[test]
 fn test_encode_message_with_args() {
     let msg_packet = OscPacket::Message(OscMessage {
         addr: "/another/address/1".to_string(),


### PR DESCRIPTION
From the spec at http://opensoundcontrol.org/spec-1_0
> An OSC Bundle consists of the OSC-string "#bundle" followed by an OSC Time Tag, followed by zero or more OSC Bundle Elements. The OSC-timetag is a 64-bit fixed point time tag whose semantics are described below.
>
> An OSC Bundle Element consists of its size and its contents. The size is an int32 representing the number of 8-bit bytes in the contents, and will always be a multiple of 4. The contents are either an OSC Message or an OSC Bundle.

I discovered this wasn't supported in the wild where a specific OSC plugin for a DAW seems to be using empty bundles as heartbeat messages, which would cause the library to panic.

The function names in the code seem to reflect some confusion around the "Bundle Element", the `read_bundle_element()` function for example reads the _contents_ of the element, but the way I interpret the spec is that an "element" is the tuple (size, content). If you think it's worth it I could try to refactor the `read_bundle_element` and `read_bundle_element_size` functions to match this, just to align code structure with spec concepts.