### PR TITLE
Implement std::error::Error for OscError

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-use std::{io, string};
+use std::{error, fmt, io, string};
 
 /// Represents errors returned by `decode` or `encode`.
 #[derive(Debug)]
@@ -12,4 +12,30 @@ pub enum OscError {
     BadArg(String),
     BadBundle(String),
     Unimplemented,
+}
+
+impl fmt::Display for OscError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            OscError::StringError(err) => write!(f, "reading OSC string as utf-8: {}", err),
+            OscError::ReadError(err) => write!(f, "reading from buffer: {}", err),
+            OscError::BadPacket(msg) => write!(f, "{}", msg),
+            OscError::BadAddress(msg) => write!(f, "{}", msg),
+            OscError::BadMessage(msg) => write!(f, "bad OSC message: {}", msg),
+            OscError::BadString(msg) => write!(f, "bad OSC string: {}", msg),
+            OscError::BadArg(msg) => write!(f, "bad OSC argument: {}", msg),
+            OscError::BadBundle(msg) => write!(f, "bad OSC bundle: {}", msg),
+            OscError::Unimplemented => write!(f, "unimplemented"),
+        }
+    }
+}
+
+impl error::Error for OscError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            OscError::StringError(ref err) => Some(err),
+            OscError::ReadError(ref err) => Some(err),
+            _ => None,
+        }
+    }
 }


### PR DESCRIPTION
Among other things, this allows `OscError` to be used with the `?`
operator in functions that return `Result<_, Box<dyn Error>>`. It also
makes `?` work with functions that use the Error type from the popular
anyhow crate.