### PR TITLE
Feature/no std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 
 [features]
 lints = ["clippy"]
-std = []
+std = ["regex"]
 default = ["std"]
 
 [dependencies]
-byteorder = {version="1", no-default-features=true}
+byteorder = {version="1", default-features=false}
+nom = { git = "https://github.com/Geal/nom", default-features=false, features=["alloc"] }
 clippy = {version="^0", optional=true}
-regex = "1.5"
-nom = { version = "7.0.0", default-features = false, features=["alloc"] }
+regex = { version="1.5", optional=true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ readme = "README.md"
 
 [features]
 lints = ["clippy"]
+std = []
+default = ["std"]
 
 [dependencies]
 byteorder = {version="1", no-default-features=true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 lints = ["clippy"]
 
 [dependencies]
-byteorder = "1"
+byteorder = {version="1", no-default-features=true}
 clippy = {version="^0", optional=true}
 regex = "1.5"
-nom = "7"
+nom = { version = "7.0.0", default-features = false, features=["alloc"] }

--- a/benches/decoder_bench.rs
+++ b/benches/decoder_bench.rs
@@ -13,5 +13,5 @@ fn bench_decode(b: &mut Bencher) {
         73, 76, 76, 65, 84, 79, 82, 83, 47, 79, 83, 67, 50, 47, 65, 68, 83, 82, 47, 122, 0, 0, 0,
         0, 44, 102, 102, 102, 102, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
-    b.iter(|| rosc::decoder::decode(&raw_msg).unwrap());
+    b.iter(|| rosc::decoder::decode_udp(&raw_msg).unwrap());
 }

--- a/examples/receiver.rs
+++ b/examples/receiver.rs
@@ -25,7 +25,7 @@ fn main() {
         match sock.recv_from(&mut buf) {
             Ok((size, addr)) => {
                 println!("Received packet with size {} from: {}", size, addr);
-                let packet = rosc::decoder::decode(&buf[..size]).unwrap();
+                let (_, packet) = rosc::decoder::decode_udp(&buf[..size]).unwrap();
                 handle_packet(packet);
             }
             Err(e) => {

--- a/examples/receiver.rs
+++ b/examples/receiver.rs
@@ -14,7 +14,7 @@ fn main() {
     }
     let addr = match SocketAddrV4::from_str(&args[1]) {
         Ok(addr) => addr,
-        Err(_) => panic!(usage),
+        Err(_) => panic!("{}", usage),
     };
     let sock = UdpSocket::bind(addr).unwrap();
     println!("Listening to {}", addr);

--- a/examples/sender.rs
+++ b/examples/sender.rs
@@ -18,7 +18,7 @@ fn main() {
         &args[0]
     );
     if args.len() < 3 {
-        panic!(usage);
+        panic!("{}", usage);
     }
     let host_addr = get_addr_from_arg(&args[1]);
     let to_addr = get_addr_from_arg(&args[2]);

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,5 +1,8 @@
 use crate::errors::OscError;
 
+use alloc::borrow::ToOwned;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use nom::branch::alt;
 use nom::bytes::complete::{is_not, tag, take_till1};
 use nom::character::complete::char;
@@ -20,7 +23,7 @@ impl Matcher {
 
     /// Instantiates a new `Matcher` with the given address pattern.
     /// An error will be returned if the given address pattern is invalid.
-    /// 
+    ///
     /// Matcher should be instantiated once per pattern and reused because its construction requires parsing the address pattern which is computationally expensive.
     ///
     /// A valid address pattern begins with a `/` and contains at least a method name, e.g. `/tempo`.
@@ -31,14 +34,14 @@ impl Matcher {
     /// - `[a-z]` are basically regex [character classes](https://www.regular-expressions.info/charclass.html)
     /// - `{foo,bar}` is an alternative, matching either `foo` or `bar`
     /// - everything else is matched literally
-    /// 
+    ///
     /// Refer to the OSC specification for details about address pattern matching: <osc-message-dispatching-and-pattern-matching>.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rosc::address::Matcher;
-    /// 
+    ///
     /// Matcher::new("/tempo").expect("valid address");
     /// Matcher::new("").expect_err("address does not start with a slash");
     /// ```
@@ -50,15 +53,15 @@ impl Matcher {
     /// Match an OSC address against an address pattern.
     /// If the address matches the pattern the result will be `true`, otherwise `false`.
     /// An error is returned if the given OSC address is not valid.
-    /// 
+    ///
     /// A valid OSC address begins with a `/` and contains at least a method name, e.g. `/tempo`.
     /// Despite OSC address patterns a plain address must not include any of the following characters `#*,/?[]{}`.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rosc::address::Matcher;
-    /// 
+    ///
     /// let matcher = Matcher::new("/oscillator/[0-9]/{frequency,phase}").unwrap();
     /// assert!(matcher.match_address("/oscillator/1/frequency").unwrap());
     /// assert!(matcher.match_address("/oscillator/8/phase").unwrap());

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,19 +1,6 @@
 use crate::errors::OscError;
-use crate::types::{
-    OscArray,
-    OscBundle,
-    OscColor,
-    OscMessage,
-    OscMidiMessage,
-    OscPacket,
-    OscTime,
-    OscType,
-};
-
-use crate::alloc::{
-    string::{ String, ToString },
-    vec::Vec,
-};
+use crate::types::{OscArray, OscBundle, OscColor, OscMessage, OscMidiMessage, OscPacket, OscTime, OscType};
+use crate::alloc::{string::{String, ToString}, vec::Vec};
 
 use nom::Offset;
 use nom::sequence::terminated;
@@ -21,11 +8,7 @@ use nom::bytes::complete::{take, take_till};
 use nom::combinator::{map, map_parser};
 use nom::multi::many0;
 use nom::number::complete::{be_f32, be_f64, be_i32, be_i64, be_u32};
-use nom::{
-    IResult,
-    combinator::map_res,
-    sequence::tuple
-};
+use nom::{IResult,combinator::map_res,sequence::tuple};
 
 /// Common MTU size for ethernet
 pub const MTU: usize = 1536;

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,13 +1,36 @@
-use crate::encoder;
+use crate::NomResult;
 use crate::errors::OscError;
 use crate::types::{
-    OscArray, OscBundle, OscColor, OscMessage, OscMidiMessage, OscPacket, OscTime, OscType, Result,
+    OscArray,
+    OscBundle,
+    OscColor,
+    OscMessage,
+    OscMidiMessage,
+    OscPacket,
+    OscTime,
+    OscType,
 };
 
+#[cfg(feature = "std")]
 use std::io::{BufRead, Read};
+#[cfg(feature = "std")]
 use std::{char, io};
+use crate::alloc::{
+    string::{ String, ToString },
+    vec::Vec,
+};
 
-use byteorder::{BigEndian, ReadBytesExt};
+use nom::sequence::terminated;
+use nom::{Offset};
+use nom::bytes::complete::{take, take_till};
+use nom::combinator::{map, map_parser};
+use nom::multi::many0;
+use nom::number::complete::{be_f32, be_f64, be_i32, be_i64, be_u32};
+use nom::{
+    IResult,
+    combinator::map_res,
+    sequence::tuple
+};
 
 /// Common MTU size for ethernet
 pub const MTU: usize = 1536;
@@ -15,114 +38,93 @@ pub const MTU: usize = 1536;
 /// Takes an byte slice as argument and returns an
 /// OSC packet on success or an `OscError` if the slice
 /// does not contain a valid OSC message.
-pub fn decode(msg: &[u8]) -> Result<OscPacket> {
-    if msg.is_empty() {
-        return Err(OscError::BadPacket("Empty packet."));
+pub fn decode(msg: &[u8]) -> NomResult<OscPacket> {
+    decode_packet(msg, msg).map(|(_, packet)| packet)
+}
+
+fn decode_packet<'a>(input: &'a [u8], original_input: &'a [u8]) -> IResult<&'a [u8], OscPacket, OscError> {
+    if input.is_empty() {
+        return Err(nom::Err::Error(OscError::BadPacket("Empty packet.")));
     }
 
-    match msg[0] as char {
-        '/' => decode_message(msg),
-        '#' => decode_bundle(msg),
-        _ => Err(OscError::BadPacket("Unknown message format.")),
+    match input[0] as char {
+        '/' => decode_message(input, original_input),
+        '#' => decode_bundle(input, original_input),
+        _ => Err(nom::Err::Error(OscError::BadPacket("Unknown message format."))),
     }
 }
 
-fn decode_message(msg: &[u8]) -> Result<OscPacket> {
-    let mut cursor: io::Cursor<&[u8]> = io::Cursor::new(msg);
-
-    let addr: String = read_osc_string(&mut cursor)?;
-    let type_tags: String = read_osc_string(&mut cursor)?;
+fn decode_message<'a>(input: &'a [u8], original_input: &'a [u8]) -> IResult<&'a [u8], OscPacket, OscError> {
+    let (input, addr) = read_osc_string(input, original_input)?;
+    let (input, type_tags) = read_osc_string(input, original_input)?;
 
     if type_tags.len() > 1 {
-        let args: Vec<OscType> = read_osc_args(&mut cursor, type_tags)?;
-        Ok(OscPacket::Message(OscMessage { addr, args }))
+        let (input, args) = read_osc_args(input, original_input, type_tags)?;
+        Ok((input, OscPacket::Message(OscMessage { addr, args })))
     } else {
-        Ok(OscPacket::Message(OscMessage { addr, args: vec![] }))
+        Ok((input, OscPacket::Message(OscMessage { addr, args: vec![] })))
     }
 }
 
-fn decode_bundle(msg: &[u8]) -> Result<OscPacket> {
-    let mut cursor: io::Cursor<&[u8]> = io::Cursor::new(msg);
-
-    let bundle_tag = read_osc_string(&mut cursor)?;
+fn decode_bundle<'a>(input: &'a [u8], original_input: &'a [u8]) -> IResult<&'a [u8], OscPacket, OscError> {
+    let (input, bundle_tag) = read_osc_string(input, original_input)?;
     if bundle_tag != "#bundle" {
-        return Err(OscError::BadBundle(format!(
+        return Err(nom::Err::Error(OscError::BadBundle(format!(
             "Wrong bundle specifier: {}",
             bundle_tag
-        )));
+        ))));
     }
 
-    let time_tag = read_time_tag(&mut cursor)?;
+    let (input, (timetag, content)) = tuple((
+        read_time_tag,
+        many0(|input| read_bundle_element(input, original_input)),
+    ))(input)?;
 
-    let mut bundle: Vec<OscPacket> = Vec::new();
-
-    // Empty bundle
-    if msg.len() == cursor.position() as usize {
-        return Ok(OscPacket::Bundle(OscBundle {
-            timetag: time_tag,
-            content: bundle,
-        }));
-    }
-
-    let mut elem_size = read_bundle_element_size(&mut cursor)?;
-
-    while msg.len() >= (cursor.position() as usize) + elem_size {
-        let packet = read_bundle_element_content(&mut cursor, elem_size)?;
-        bundle.push(packet);
-
-        if msg.len() == cursor.position() as usize {
-            break;
-        }
-
-        elem_size = read_bundle_element_size(&mut cursor)?;
-    }
-
-    Ok(OscPacket::Bundle(OscBundle {
-        timetag: time_tag,
-        content: bundle,
-    }))
+    Ok((
+        input,
+        OscPacket::Bundle(OscBundle {
+            timetag,
+            content,
+        }),
+    ))
 }
 
-fn read_bundle_element_size(cursor: &mut io::Cursor<&[u8]>) -> Result<usize> {
-    cursor
-        .read_u32::<BigEndian>()
-        .map(|size| size as usize)
-        .map_err(OscError::ReadError)
+fn read_bundle_element<'a>(input: &'a [u8], original_input: &'a [u8]) -> IResult<&'a [u8], OscPacket, OscError> {
+    let (input, elem_size) = be_u32(input)?;
+
+    let result = map_parser(
+        |input| {
+            take(elem_size)(input).map_err(|_: nom::Err<OscError>| {
+                nom::Err::Error(OscError::BadBundle(
+                    "Bundle shorter than expected!".to_string(),
+                ))
+            })
+        },
+        |input| decode_packet(input, original_input),
+    )(input);
+    drop(elem_size);
+    result
 }
 
-fn read_bundle_element_content(
-    cursor: &mut io::Cursor<&[u8]>,
-    elem_size: usize,
-) -> Result<OscPacket> {
-    let mut buf: Vec<u8> = Vec::with_capacity(elem_size);
-
-    let mut handle = cursor.take(elem_size as u64);
-
-    let cnt = handle.read_to_end(&mut buf).map_err(OscError::ReadError)?;
-
-    if cnt == elem_size {
-        decode(&buf)
-    } else {
-        Err(OscError::BadBundle(
-            "Bundle shorter than expected!".to_string(),
-        ))
-    }
+fn read_osc_string<'a>(input: &'a [u8], original_input: &'a [u8]) -> IResult<&'a [u8], String, OscError> {
+    map_res(
+        terminated(
+            take_till(|c| c == b'0'),
+            |input| pad_to_4_byte_boundary(input, original_input),
+        ),
+        |str_buf| {
+            String::from_utf8(str_buf.into())
+                .map_err(OscError::StringError)
+                .map(|s| s.trim_matches(0u8 as char).to_string())
+        },
+    )(input)
 }
 
-fn read_osc_string(cursor: &mut io::Cursor<&[u8]>) -> Result<String> {
-    let mut str_buf: Vec<u8> = Vec::new();
-    // ignore returned byte count
-    cursor
-        .read_until(0, &mut str_buf)
-        .map_err(OscError::ReadError)?;
-    pad_cursor(cursor);
-    // convert to String and remove nul bytes
-    String::from_utf8(str_buf)
-        .map_err(OscError::StringError)
-        .map(|s| s.trim_matches(0u8 as char).to_string())
-}
-
-fn read_osc_args(cursor: &mut io::Cursor<&[u8]>, raw_type_tags: String) -> Result<Vec<OscType>> {
+fn read_osc_args<'a>(
+    mut input: &'a[u8],
+    original_input: &'a [u8],
+    raw_type_tags: String,
+) ->  IResult<&'a [u8], Vec<OscType>, OscError> {
     let type_tags: Vec<char> = raw_type_tags.chars().skip(1).collect();
 
     let mut args: Vec<OscType> = Vec::with_capacity(type_tags.len());
@@ -139,124 +141,109 @@ fn read_osc_args(cursor: &mut io::Cursor<&[u8]>, raw_type_tags: String) -> Resul
             let array = OscType::Array(OscArray { content: args });
             match stack.pop() {
                 Some(stashed) => args = stashed,
-                None => return Err(OscError::BadMessage("Encountered ] outside array")),
+                None => return Err(nom::Err::Error(OscError::BadMessage(
+                    "Encountered ] outside array"
+                ))),
             }
             args.push(array);
         } else {
-            let arg: OscType = read_osc_arg(cursor, tag)?;
-            args.push(arg);
+            let input_and_arg = read_osc_arg(input, original_input, tag)?;
+            input = input_and_arg.0;
+            args.push(input_and_arg.1);
         }
     }
-    Ok(args)
+    Ok((input, args))
 }
 
-fn read_osc_arg(cursor: &mut io::Cursor<&[u8]>, tag: char) -> Result<OscType> {
+fn read_osc_arg<'a>(input: &'a[u8], original_input: &'a [u8], tag: char) -> IResult<&'a[u8], OscType, OscError> {
     match tag {
-        'f' => cursor
-            .read_f32::<BigEndian>()
-            .map(OscType::Float)
-            .map_err(OscError::ReadError),
-        'd' => cursor
-            .read_f64::<BigEndian>()
-            .map(OscType::Double)
-            .map_err(OscError::ReadError),
-        'i' => cursor
-            .read_i32::<BigEndian>()
-            .map(OscType::Int)
-            .map_err(OscError::ReadError),
-        'h' => cursor
-            .read_i64::<BigEndian>()
-            .map(OscType::Long)
-            .map_err(OscError::ReadError),
-        's' => read_osc_string(cursor).map(OscType::String),
-        't' => read_time_tag(cursor).map(OscType::Time),
-        'b' => read_blob(cursor),
-        'r' => read_osc_color(cursor),
-        'T' => Ok(true.into()),
-        'F' => Ok(false.into()),
-        'N' => Ok(OscType::Nil),
-        'I' => Ok(OscType::Inf),
-        'c' => read_char(cursor),
-        'm' => read_midi_message(cursor),
-        _ => Err(OscError::BadArg(format!(
+        'f' => map(be_f32, OscType::Float)(input),
+        'd' => map(be_f64, OscType::Double)(input),
+        'i' => map(be_i32, OscType::Int)(input),
+        'h' => map(be_i64, OscType::Long)(input),
+        's' => {
+            read_osc_string(input, original_input)
+                .map(|(remainder, string)| (remainder, OscType::String(string)))
+        }
+        't' => read_time_tag(input).map(|(remainder, time)| {
+            (remainder, OscType::Time(time))
+        }),
+        'b' => read_blob(input, original_input),
+        'r' => read_osc_color(input),
+        'T' => Ok((input, true.into())),
+        'F' => Ok((input, false.into())),
+        'N' => Ok((input, OscType::Nil)),
+        'I' => Ok((input, OscType::Inf)),
+        'c' => read_char(input),
+        'm' => read_midi_message(input),
+        _ => Err(nom::Err::Error(OscError::BadArg(format!(
             "Type tag \"{}\" is not implemented!",
             tag
-        ))),
+        )))),
     }
 }
 
-fn read_char(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
-    let opt_char = cursor
-        .read_u32::<BigEndian>()
-        .map(char::from_u32)
-        .map_err(OscError::ReadError)?;
-    match opt_char {
-        Some(c) => Ok(OscType::Char(c)),
-        None => Err(OscError::BadArg("Argument is not a char!".to_string())),
-    }
+fn read_char(input: &[u8]) -> IResult<&[u8], OscType, OscError> {
+    map_res(
+        be_u32,
+        |b| {
+            let opt_char = char::from_u32(b);
+            match opt_char {
+                Some(c) => Ok(OscType::Char(c)),
+                None => Err(OscError::BadArg(
+                    "Argument is not a char!".to_string(),
+                )),
+            }
+        },
+    )(input)
 }
 
-fn read_blob(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
-    let size: usize = cursor
-        .read_u32::<BigEndian>()
-        .map_err(OscError::ReadError)? as usize;
-    let mut byte_buf: Vec<u8> = Vec::with_capacity(size);
+fn read_blob<'a>(input: &'a[u8], original_input: &'a [u8]) -> IResult<&'a[u8], OscType, OscError> {
+    let (input, size) = be_u32(input)?;
 
-    cursor
-        .take(size as u64)
-        .read_to_end(&mut byte_buf)
-        .map_err(OscError::ReadError)?;
-
-    pad_cursor(cursor);
-
-    Ok(OscType::Blob(byte_buf))
+    map(
+        terminated(
+            take(size),
+            |input| pad_to_4_byte_boundary(input, original_input),
+        ),
+        |blob| OscType::Blob(blob.into()),
+    )(input)
 }
 
-fn read_time_tag(cursor: &mut io::Cursor<&[u8]>) -> Result<OscTime> {
-    let seconds = cursor
-        .read_u32::<BigEndian>()
-        .map_err(OscError::ReadError)?;
-    let fractional = cursor
-        .read_u32::<BigEndian>()
-        .map_err(OscError::ReadError)?;
-
-    Ok(OscTime {
-        seconds,
-        fractional,
-    })
+fn read_time_tag<'a>(input: &'a[u8]) -> IResult<&'a[u8], OscTime, OscError> {
+    map(
+        tuple((be_u32, be_u32)),
+        |(seconds, fractional)| OscTime {
+            seconds,
+            fractional,
+        },
+    )(input)
 }
 
-fn read_midi_message(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
-    let mut buf: Vec<u8> = Vec::with_capacity(4);
-    cursor
-        .take(4)
-        .read_to_end(&mut buf)
-        .map_err(OscError::ReadError)?;
-
-    Ok(OscType::Midi(OscMidiMessage {
-        port: buf[0],
-        status: buf[1],
-        data1: buf[2],
-        data2: buf[3],
-    }))
+fn read_midi_message<'a>(input: &'a[u8]) -> IResult<&'a[u8], OscType, OscError> {
+    map(take(4usize), |buf: &[u8]| {
+        OscType::Midi(OscMidiMessage {
+            port: buf[0],
+            status: buf[1],
+            data1: buf[2],
+            data2: buf[3],
+        })
+    })(input)
 }
 
-fn read_osc_color(cursor: &mut io::Cursor<&[u8]>) -> Result<OscType> {
-    let mut buf: Vec<u8> = Vec::with_capacity(4);
-    cursor
-        .take(4)
-        .read_to_end(&mut buf)
-        .map_err(OscError::ReadError)?;
-
-    Ok(OscType::Color(OscColor {
-        red: buf[0],
-        green: buf[1],
-        blue: buf[2],
-        alpha: buf[3],
-    }))
+fn read_osc_color<'a>(input: &'a[u8]) -> IResult<&'a[u8], OscType, OscError> {
+    map(take(4usize), |buf: &[u8]| {
+        OscType::Color(OscColor {
+            red: buf[0],
+            green: buf[1],
+            blue: buf[2],
+            alpha: buf[3],
+        })
+    })(input)
 }
 
-fn pad_cursor(cursor: &mut io::Cursor<&[u8]>) {
-    let pos = cursor.position();
-    cursor.set_position(encoder::pad(pos));
+fn pad_to_4_byte_boundary<'a>(input: &'a[u8], original_input: &'a[u8]) -> IResult<&'a[u8], (), OscError> {
+    let offset = original_input.offset(input);
+    let (input, _) = take(offset)(input)?;
+    Ok((input, ()))
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,9 +1,6 @@
 use crate::errors::OscError;
 use crate::types::{OscBundle, OscMessage, OscPacket, OscTime, OscType, Result};
-use crate::alloc::{
-    string::{ String, ToString },
-    vec::Vec,
-};
+use crate::alloc::{string::{ String, ToString }, vec::Vec};
 
 use byteorder::{BigEndian, ByteOrder};
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,5 +1,9 @@
 use crate::errors::OscError;
 use crate::types::{OscBundle, OscMessage, OscPacket, OscTime, OscType, Result};
+use crate::alloc::{
+    string::{ String, ToString },
+    vec::Vec,
+};
 
 use byteorder::{BigEndian, ByteOrder};
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "std")]
-use std::{error, io};
+use std::error;
 use alloc::{
     fmt,
     string::{ self, String },
@@ -70,7 +70,6 @@ impl error::Error for OscError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             OscError::StringError(ref err) => Some(err),
-            OscError::ReadError(ref err) => Some(err),
             _ => None,
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,10 +1,17 @@
-use std::{error, fmt, io, string};
+#[cfg(feature = "std")]
+use std::{error, io};
+use alloc::{
+    fmt,
+    string::{ self, String },
+};
+use nom::error::{ErrorKind, FromExternalError, ParseError};
 
 /// Represents errors returned by `decode` or `encode`.
 #[derive(Debug)]
 pub enum OscError {
     StringError(string::FromUtf8Error),
-    ReadError(io::Error),
+    ReadError(ErrorKind),
+    BadChar(char),
     BadPacket(&'static str),
     BadMessage(&'static str),
     BadString(&'static str),
@@ -20,7 +27,8 @@ impl fmt::Display for OscError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             OscError::StringError(err) => write!(f, "reading OSC string as utf-8: {}", err),
-            OscError::ReadError(err) => write!(f, "reading from buffer: {}", err),
+            OscError::ReadError(kind) => write!(f, "error reading from buffer: {:?}", kind),
+            OscError::BadChar(char) => write!(f, "parser error at char: {:?}", char),
             OscError::BadPacket(msg) => write!(f, "bad OSC packet: {}", msg),
             OscError::BadMessage(msg) => write!(f, "bad OSC message: {}", msg),
             OscError::BadString(msg) => write!(f, "bad OSC string: {}", msg),
@@ -34,6 +42,30 @@ impl fmt::Display for OscError {
     }
 }
 
+impl<I> ParseError<I> for OscError {
+    fn from_error_kind(_input: I, kind: ErrorKind) -> Self {
+        Self::ReadError(kind)
+    }
+    fn append(_input: I, _kind: ErrorKind, other: Self) -> Self {
+        other
+    }
+
+    fn from_char(_input: I, c: char) -> Self {
+        Self::BadChar(c)
+    }
+
+    fn or(self, _other: Self) -> Self {
+        self
+    }
+}
+
+impl<I> FromExternalError<I, OscError> for OscError {
+    fn from_external_error(_input: I, _kind: ErrorKind, e: OscError) -> Self {
+        e
+    }
+}
+
+#[cfg(feature = "std")]
 impl error::Error for OscError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,6 @@
 #[cfg(feature = "std")]
 use std::error;
-use alloc::{
-    fmt,
-    string::{ self, String },
-};
+use alloc::{fmt, string::{ self, String }};
 use nom::error::{ErrorKind, FromExternalError, ParseError};
 
 /// Represents errors returned by `decode` or `encode`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use] extern crate alloc;
-#[cfg(feature = "std")]
 #[macro_use] extern crate core;
-// #[cfg(feature = "std")]
-// extern crate std as alloc;
 
 extern crate nom;
 extern crate byteorder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,15 @@
 //! **rosc** is an implementation of the [OSC 1.0](http://opensoundcontrol.org/spec-1_0) protocol in pure Rust.
 //!
 
-extern crate byteorder;
-extern crate regex;
+// #[cfg(all(feature = "alloc", not(feature = "std")))]
+#![no_std]
+
+#[macro_use] extern crate alloc;
+
 extern crate nom;
+extern crate byteorder;
+#[cfg(feature = "std")]
+extern crate regex;
 
 /// Crate specific error types.
 mod errors;
@@ -18,4 +24,5 @@ pub mod decoder;
 /// Encodes an `OscPacket` to a byte vector.
 pub mod encoder;
 /// Address checking and matching methods
+#[cfg(feature = "std")]
 pub mod address;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,13 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(not(feature = "std"))]
 #[macro_use] extern crate alloc;
-#[macro_use] extern crate core;
+
+#[cfg(feature = "std")]
+extern crate std as core;
+#[cfg(feature = "std")]
+#[macro_use] extern crate std as alloc;
 
 extern crate nom;
 extern crate byteorder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
 //! **rosc** is an implementation of the [OSC 1.0](http://opensoundcontrol.org/spec-1_0) protocol in pure Rust.
 //!
 
-// #[cfg(all(feature = "alloc", not(feature = "std")))]
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use] extern crate alloc;
+#[cfg(feature = "std")]
+#[macro_use] extern crate core;
+// #[cfg(feature = "std")]
+// extern crate std as alloc;
 
 extern crate nom;
 extern crate byteorder;

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,13 +14,16 @@ use crate::alloc::{string::{ String, ToString }, vec::Vec};
 /// # Examples
 ///
 /// ```
-/// use rosc::OscTime;
-/// use std::{convert::TryFrom, time::UNIX_EPOCH};
+/// #[cfg(feature = "std")]
+/// {
+///     use rosc::OscTime;
+///     use std::{convert::TryFrom, time::UNIX_EPOCH};
 ///
-/// assert_eq!(
-///     OscTime::try_from(UNIX_EPOCH).unwrap(),
-///     OscTime::from((2_208_988_800, 0))
-/// );
+///     assert_eq!(
+///         OscTime::try_from(UNIX_EPOCH).unwrap(),
+///         OscTime::from((2_208_988_800, 0))
+///     );
+/// }
 /// ```
 ///
 /// # Conversions between `(u32, u32)`

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,23 +1,12 @@
 use crate::errors;
 #[cfg(feature = "std")]
-use core::{
-    fmt::{self, Display},
-};
-use core::{
-    iter::FromIterator,
-    result,
-};
+use core::fmt::{self, Display};
+use core::{iter::FromIterator, result};
 
 #[cfg(feature = "std")]
-use std::{
-    convert::{TryFrom, TryInto},
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::{convert::{TryFrom, TryInto}, time::{Duration, SystemTime, UNIX_EPOCH}};
 
-use crate::alloc::{
-    string::{ String, ToString },
-    vec::Vec,
-};
+use crate::alloc::{string::{ String, ToString }, vec::Vec};
 
 /// A time tag in OSC message consists of two 32-bit integers where the first one denotes the number of seconds since 1900-01-01 and the second the fractions of a second.
 /// For details on its semantics see http://opensoundcontrol.org/node/3/#timetags

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,6 @@ use core::{
 #[cfg(feature = "std")]
 use std::{
     convert::{TryFrom, TryInto},
-    error,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -319,6 +318,7 @@ mod tests {
     #[cfg(feature = "std")]
     use std::time::UNIX_EPOCH;
 
+    #[cfg(feature = "std")]
     const TOLERANCE_NANOS: u64 = 5;
 
     #[cfg(feature = "std")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,11 +1,23 @@
 use crate::errors;
+#[cfg(feature = "std")]
+use core::{
+    fmt::{self, Display},
+};
+use core::{
+    iter::FromIterator,
+    result,
+};
+
+#[cfg(feature = "std")]
 use std::{
     convert::{TryFrom, TryInto},
     error,
-    fmt::{self, Display},
-    iter::FromIterator,
-    result,
     time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use crate::alloc::{
+    string::{ String, ToString },
+    vec::Vec,
 };
 
 /// A time tag in OSC message consists of two 32-bit integers where the first one denotes the number of seconds since 1900-01-01 and the second the fractions of a second.
@@ -52,6 +64,7 @@ pub struct OscTime {
     pub fractional: u32,
 }
 
+#[cfg(feature = "std")]
 impl OscTime {
     const UNIX_OFFSET: u64 = 2_208_988_800; // From RFC 5905
     const TWO_POW_32: f64 = (u32::MAX as f64) + 1.0; // Number of bits in a `u32`
@@ -60,10 +73,11 @@ impl OscTime {
     const SECONDS_PER_NANO: f64 = 1.0 / OscTime::NANOS_PER_SECOND;
 }
 
+#[cfg(feature = "std")]
 impl TryFrom<SystemTime> for OscTime {
     type Error = OscTimeError;
 
-    fn try_from(time: SystemTime) -> std::result::Result<OscTime, OscTimeError> {
+    fn try_from(time: SystemTime) -> core::result::Result<OscTime, OscTimeError> {
         let duration_since_epoch = time
             .duration_since(UNIX_EPOCH)
             .map_err(|_| OscTimeError(OscTimeErrorKind::BeforeEpoch))?
@@ -79,6 +93,7 @@ impl TryFrom<SystemTime> for OscTime {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<OscTime> for SystemTime {
     fn from(time: OscTime) -> SystemTime {
         let nanos =
@@ -106,16 +121,19 @@ impl From<OscTime> for (u32, u32) {
     }
 }
 
+#[cfg(feature = "std")]
 /// An error returned by conversions involving [`OscTime`].
 #[derive(Debug)]
 pub struct OscTimeError(OscTimeErrorKind);
 
+#[cfg(feature = "std")]
 #[derive(Debug)]
 enum OscTimeErrorKind {
     BeforeEpoch,
     Overflow,
 }
 
+#[cfg(feature = "std")]
 impl Display for OscTimeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {
@@ -129,7 +147,7 @@ impl Display for OscTimeError {
     }
 }
 
-impl error::Error for OscTimeError {}
+// impl error::Error for OscTimeError {}
 
 /// see OSC Type Tag String: [OSC Spec. 1.0](http://opensoundcontrol.org/spec-1_0)
 /// padding: zero bytes (n*4)
@@ -189,6 +207,8 @@ impl From<(u32, u32)> for OscType {
         OscType::Time(time.into())
     }
 }
+
+#[cfg(feature = "std")]
 impl TryFrom<SystemTime> for OscType {
     type Error = OscTimeError;
 
@@ -196,6 +216,7 @@ impl TryFrom<SystemTime> for OscType {
         time.try_into().map(OscType::Time)
     }
 }
+
 impl OscType {
     pub fn time(self) -> Option<OscTime> {
         match self {
@@ -272,6 +293,7 @@ impl<T: Into<OscType>> FromIterator<T> for OscArray {
 }
 
 pub type Result<T> = result::Result<T, errors::OscError>;
+pub type NomResult<T> = result::Result<T, nom::Err<errors::OscError>>;
 
 impl From<String> for OscMessage {
     fn from(s: String) -> OscMessage {
@@ -292,11 +314,14 @@ impl<'a> From<&'a str> for OscMessage {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "std")]
     use super::*;
+    #[cfg(feature = "std")]
     use std::time::UNIX_EPOCH;
 
     const TOLERANCE_NANOS: u64 = 5;
 
+    #[cfg(feature = "std")]
     #[test]
     fn system_times_can_be_converted_to_and_from_osc() {
         let times = vec![UNIX_EPOCH, SystemTime::now()];
@@ -308,6 +333,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn osc_times_can_be_converted_to_and_from_system_times() {
         let mut times = vec![];
@@ -337,11 +363,13 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn osc_time_cannot_represent_times_before_1970_01_01() {
         assert!(OscTime::try_from(UNIX_EPOCH - Duration::from_secs(1)).is_err())
     }
 
+    #[cfg(feature = "std")]
     fn assert_eq_system_times(a: SystemTime, b: SystemTime) {
         let difference = if a < b {
             b.duration_since(a).unwrap()
@@ -359,6 +387,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "std")]
     fn assert_eq_osc_times(a: OscTime, b: OscTime) {
         // I did not want to implement subtraction with carrying in order to implement this in the
         // same way as the alternative for system times. Intsead we are compare each part of the

--- a/src/types.rs
+++ b/src/types.rs
@@ -292,7 +292,6 @@ impl<T: Into<OscType>> FromIterator<T> for OscArray {
 }
 
 pub type Result<T> = result::Result<T, errors::OscError>;
-pub type NomResult<T> = result::Result<T, nom::Err<errors::OscError>>;
 
 impl From<String> for OscMessage {
     fn from(s: String) -> OscMessage {

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -1,7 +1,7 @@
 extern crate rosc;
 
 #[cfg(feature = "std")]
-use rosc::{OscError, address::Matcher};
+use rosc::address::Matcher;
 
 #[cfg(feature = "std")]
 #[test]

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -1,7 +1,9 @@
 extern crate rosc;
 
+#[cfg(feature = "std")]
 use rosc::{OscError, address::Matcher};
 
+#[cfg(feature = "std")]
 #[test]
 fn test_matcher() {
     let matcher = Matcher::new("/oscillator/[0-9]/*/pre[!1234?*]post/{frequency,phase}/x?")
@@ -21,6 +23,7 @@ fn test_matcher() {
     matcher.match_address("invalid_address").expect_err("should fail because address does not start with a slash");
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_bad_address_pattern() {
     let expected_err = "bad OSC address pattern: bad address pattern";
@@ -32,6 +35,7 @@ fn test_bad_address_pattern() {
     assert_eq!(Matcher::new("/unclosed/[range-").unwrap_err().to_string(), expected_err);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_bad_address() {
     let matcher = Matcher::new("/does-not-matter").expect("Matcher::new");

--- a/tests/decoder_test.rs
+++ b/tests/decoder_test.rs
@@ -13,15 +13,13 @@ fn test_decode_no_args() {
     let addr = encoder::encode_string(raw_addr);
     let type_tags = encoder::encode_string(",");
     let merged: Vec<u8> = addr.into_iter().chain(type_tags.into_iter()).collect();
-    let osc_packet = decoder::decode(&merged);
-    assert!(osc_packet.is_ok());
+    let osc_packet = decoder::decode(&merged).unwrap();
     match osc_packet {
-        Ok(rosc::OscPacket::Message(msg)) => {
+        rosc::OscPacket::Message(msg) => {
             assert_eq!(raw_addr, msg.addr);
             assert!(msg.args.is_empty());
         }
-        Ok(_) => panic!("Expected an OscMessage!"),
-        Err(e) => panic!(e),
+        _ => panic!("Expected an OscMessage!"),
     }
 }
 
@@ -31,13 +29,12 @@ fn test_decode_empty_bundle() {
     let content = vec![];
     let packet = encoder::encode(&OscPacket::Bundle(OscBundle { timetag, content })).unwrap();
     let osc_packet = decoder::decode(&packet);
-    match osc_packet {
-        Ok(rosc::OscPacket::Bundle(bundle)) => {
+    match osc_packet.unwrap() {
+        rosc::OscPacket::Bundle(bundle) => {
             assert_eq!(timetag, bundle.timetag);
             assert!(bundle.content.is_empty());
         }
-        Ok(_) => panic!("Expected an OscBundle!"),
-        Err(e) => panic!(e),
+        _ => panic!("Expected an OscBundle!"),
     }
 }
 

--- a/tests/decoder_test.rs
+++ b/tests/decoder_test.rs
@@ -7,13 +7,15 @@ use std::mem;
 use rosc::{decoder, encoder, OscBundle, OscPacket, OscTime, OscType};
 
 #[test]
-fn test_decode_no_args() {
+fn test_decode_udp_no_args() {
     // message to build: /some/valid/address/4 ,
     let raw_addr = "/some/valid/address/4";
     let addr = encoder::encode_string(raw_addr);
     let type_tags = encoder::encode_string(",");
     let merged: Vec<u8> = addr.into_iter().chain(type_tags.into_iter()).collect();
-    let osc_packet = decoder::decode(&merged).unwrap();
+    let (remainder, osc_packet) = decoder::decode_udp(&merged).unwrap();
+
+    assert_eq!(remainder.len(), 0);
     match osc_packet {
         rosc::OscPacket::Message(msg) => {
             assert_eq!(raw_addr, msg.addr);
@@ -24,12 +26,46 @@ fn test_decode_no_args() {
 }
 
 #[test]
-fn test_decode_empty_bundle() {
+fn test_decode_tcp_vec() {
+    use rosc::OscPacket::Message;
+
+    // message to build: /some/valid/address/4 ,
+    let raw_addr = "/some/valid/address/4";
+    let addr = encoder::encode_string(raw_addr);
+    let type_tags = encoder::encode_string(",");
+    let merged: Vec<u8> = addr.into_iter().chain(type_tags.into_iter()).collect();
+
+    let tcp_msg = std::iter::repeat_with(|| merged.clone())
+        .take(2)
+        .map(|bytes| {
+            // Prefix the tcp packet with a length byte
+            let packet_size_header = (bytes.len() as u32).to_be_bytes().to_vec();
+            vec![packet_size_header, bytes].concat()
+        })
+        .flatten()
+        .collect::<Vec<u8>>();
+
+    let (remainder, osc_packet) = decoder::decode_tcp_vec(&tcp_msg).unwrap();
+
+    assert_eq!(remainder.len(), 0);
+    match &osc_packet[..] {
+        [Message(msg1), Message(msg2)] => {
+            assert_eq!(raw_addr, msg1.addr);
+            assert!(msg1.args.is_empty());
+            assert_eq!(raw_addr, msg2.addr);
+            assert!(msg2.args.is_empty());
+        }
+        _ => panic!("Expected an OscMessage!"),
+    }
+}
+
+#[test]
+fn test_decode_udp_empty_bundle() {
     let timetag = OscTime::from((4, 2));
     let content = vec![];
     let packet = encoder::encode(&OscPacket::Bundle(OscBundle { timetag, content })).unwrap();
-    let osc_packet = decoder::decode(&packet);
-    match osc_packet.unwrap() {
+    let osc_packet = decoder::decode_udp(&packet);
+    match osc_packet.unwrap().1 {
         rosc::OscPacket::Bundle(bundle) => {
             assert_eq!(timetag, bundle.timetag);
             assert!(bundle.content.is_empty());
@@ -39,7 +75,7 @@ fn test_decode_empty_bundle() {
 }
 
 #[test]
-fn test_decode_args() {
+fn test_decode_udp_args() {
     // /another/valid/address/123 ,fdih 3.1415 3.14159265359 12345678i32
     // -1234567891011
     let addr = encoder::encode_string("/another/valid/address/123");
@@ -98,7 +134,7 @@ fn test_decode_args() {
         .chain(args)
         .collect::<Vec<u8>>();
 
-    match decoder::decode(&merged).unwrap() {
+    match decoder::decode_udp(&merged).unwrap().1 {
         rosc::OscPacket::Message(msg) => {
             for arg in msg.args {
                 match arg {

--- a/tests/decoder_test.rs
+++ b/tests/decoder_test.rs
@@ -13,7 +13,7 @@ fn test_decode_no_args() {
     let addr = encoder::encode_string(raw_addr);
     let type_tags = encoder::encode_string(",");
     let merged: Vec<u8> = addr.into_iter().chain(type_tags.into_iter()).collect();
-    let osc_packet: Result<rosc::OscPacket, rosc::OscError> = decoder::decode(&merged);
+    let osc_packet = decoder::decode(&merged);
     assert!(osc_packet.is_ok());
     match osc_packet {
         Ok(rosc::OscPacket::Message(msg)) => {
@@ -30,7 +30,7 @@ fn test_decode_empty_bundle() {
     let timetag = OscTime::from((4, 2));
     let content = vec![];
     let packet = encoder::encode(&OscPacket::Bundle(OscBundle { timetag, content })).unwrap();
-    let osc_packet: Result<rosc::OscPacket, rosc::OscError> = decoder::decode(&packet);
+    let osc_packet = decoder::decode(&packet);
     match osc_packet {
         Ok(rosc::OscPacket::Bundle(bundle)) => {
             assert_eq!(timetag, bundle.timetag);

--- a/tests/encoder_test.rs
+++ b/tests/encoder_test.rs
@@ -18,7 +18,7 @@ fn test_encode_message_wo_args() {
         _ => panic!(),
     };
 
-    let dec_msg = match decoder::decode(&enc_msg).unwrap() {
+    let dec_msg = match decoder::decode_udp(&enc_msg).unwrap().1 {
         OscPacket::Message(m) => m,
         _ => panic!("Expected OscMessage!"),
     };
@@ -37,7 +37,7 @@ fn test_encode_empty_bundle() {
     assert_eq!(enc_bundle.len() % 4, 0);
     assert_eq!(enc_bundle.len(), 16);
 
-    let dec_bundle = match decoder::decode(&enc_bundle).unwrap() {
+    let dec_bundle = match decoder::decode_udp(&enc_bundle).unwrap().1 {
         OscPacket::Bundle(m) => m,
         _ => panic!("Expected OscBundle!"),
     };
@@ -99,7 +99,7 @@ fn test_encode_message_with_args() {
     let enc_msg = encoder::encode(&msg_packet).unwrap();
     assert_eq!(enc_msg.len() % 4, 0);
 
-    let dec_msg: OscMessage = match decoder::decode(&enc_msg).unwrap() {
+    let dec_msg: OscMessage = match decoder::decode_udp(&enc_msg).unwrap().1 {
         OscPacket::Message(m) => m,
         _ => panic!("Expected OscMessage!"),
     };
@@ -151,6 +151,6 @@ fn test_encode_bundle() {
     let enc_bundle = encoder::encode(&root_bundle).unwrap();
     assert_eq!(enc_bundle.len() % 4, 0);
 
-    let dec_bundle = decoder::decode(&enc_bundle).unwrap();
+    let dec_bundle = decoder::decode_udp(&enc_bundle).unwrap().1;
     assert_eq!(root_bundle, dec_bundle);
 }


### PR DESCRIPTION
I've ported rosc over to nom in order to enable no-std support for use in embedded and WASM environments. Initially this was just for my own use on a microcontroller which receives OSC commands but I saw @klingtnet 's mention here:

https://github.com/klingtnet/rosc/commit/62fa9e258bd3f9fbfe0a592842b453df30e42328

So I figured I should create a pull request proper - at the very least to have a thread for further discussion.

This is going back a bit for me (I context switched to a completely unrelated work topic last week so please excuse the hazy memory) but as I remember it I think I'd gotten it working well and compiling without issue in my esp32 no-std environment.

There were some public API changes so this would necessitate a version bump from `0.5` to `0.6`.
 