### PR TITLE
WIP: Apply clippy suggestions

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -43,7 +43,7 @@ pub fn decode_tcp_vec<'a>(msg: &'a [u8]) -> IResult<&'a [u8], Vec<OscPacket>, Os
         input = remainder;
         osc_packets.push(osc_packet);
 
-        if remainder.len() == 0 {
+        if remainder.is_empty() {
             break;
         }
     };

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -125,7 +125,6 @@ fn read_bundle_element<'a>(input: &'a [u8], original_input: &'a[u8]) -> IResult<
         },
         |input| decode_packet(input, original_input),
     )(input);
-    drop(elem_size);
     result
 }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -112,11 +112,9 @@ fn decode_bundle<'a>(
     ))
 }
 
-
 fn read_bundle_element<'a>(input: &'a [u8], original_input: &'a[u8]) -> IResult<&'a [u8], OscPacket, OscError> {
     let (input, elem_size) = be_u32(input)?;
 
-    #[allow(clippy::let_and_return)]
     let result = map_parser(
         |input| {
             take(elem_size)(input).map_err(|_: nom::Err<OscError>| {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -15,13 +15,13 @@ pub const MTU: usize = 1536;
 
 /// Takes a bytes slice representing a UDP packet and returns the OSC packet as well as a slice of
 /// any bytes remaining after the OSC packet.
-pub fn decode_udp<'a>(msg: &'a [u8]) -> IResult<&'a [u8], OscPacket, OscError> {
+pub fn decode_udp(msg: &[u8]) -> IResult<&[u8], OscPacket, OscError> {
     decode_packet(msg, msg)
 }
 
 /// Takes a bytes slice from a TCP stream (or any stream-based protocol) and returns the first OSC
 /// packet as well as a slice of the bytes remaining after the packet.
-pub fn decode_tcp<'a>(msg: &'a [u8]) -> IResult<&'a [u8], Option<OscPacket>, OscError> {
+pub fn decode_tcp(msg: &[u8]) -> IResult<&[u8], Option<OscPacket>, OscError> {
     let (input, osc_packet_length) = be_u32(msg)?;
 
     if osc_packet_length as usize > msg.len() {
@@ -35,7 +35,7 @@ pub fn decode_tcp<'a>(msg: &'a [u8]) -> IResult<&'a [u8], Option<OscPacket>, Osc
 
 /// Takes a bytes slice from a TCP stream (or any stream-based protocol) and returns a vec of all
 /// OSC packets in the slice as well as a slice of the bytes remaining after the last packet.
-pub fn decode_tcp_vec<'a>(msg: &'a [u8]) -> IResult<&'a [u8], Vec<OscPacket>, OscError> {
+pub fn decode_tcp_vec(msg: &[u8]) -> IResult<&[u8], Vec<OscPacket>, OscError> {
     let mut input = msg;
     let mut osc_packets = vec![];
 
@@ -232,7 +232,7 @@ fn read_blob<'a>(input: &'a[u8], original_input: &'a[u8]) -> IResult<&'a[u8], Os
     )(input)
 }
 
-fn read_time_tag<'a>(input: &'a[u8]) -> IResult<&'a[u8], OscTime, OscError> {
+fn read_time_tag(input: &[u8]) -> IResult<&[u8], OscTime, OscError> {
     map(
         tuple((be_u32, be_u32)),
         |(seconds, fractional)| OscTime {
@@ -242,7 +242,7 @@ fn read_time_tag<'a>(input: &'a[u8]) -> IResult<&'a[u8], OscTime, OscError> {
     )(input)
 }
 
-fn read_midi_message<'a>(input: &'a[u8]) -> IResult<&'a[u8], OscType, OscError> {
+fn read_midi_message(input: &[u8]) -> IResult<&[u8], OscType, OscError> {
     map(take(4usize), |buf: &[u8]| {
         OscType::Midi(OscMidiMessage {
             port: buf[0],
@@ -253,7 +253,7 @@ fn read_midi_message<'a>(input: &'a[u8]) -> IResult<&'a[u8], OscType, OscError> 
     })(input)
 }
 
-fn read_osc_color<'a>(input: &'a[u8]) -> IResult<&'a[u8], OscType, OscError> {
+fn read_osc_color(input: &[u8]) -> IResult<&[u8], OscType, OscError> {
     map(take(4usize), |buf: &[u8]| {
         OscType::Color(OscColor {
             red: buf[0],

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -112,9 +112,11 @@ fn decode_bundle<'a>(
     ))
 }
 
+
 fn read_bundle_element<'a>(input: &'a [u8], original_input: &'a[u8]) -> IResult<&'a [u8], OscPacket, OscError> {
     let (input, elem_size) = be_u32(input)?;
 
+    #[allow(clippy::let_and_return)]
     let result = map_parser(
         |input| {
             take(elem_size)(input).map_err(|_: nom::Err<OscError>| {

--- a/src/types.rs
+++ b/src/types.rs
@@ -329,7 +329,7 @@ mod tests {
     fn osc_times_can_be_converted_to_and_from_system_times() {
         let mut times = vec![];
         // Sweep across a few numbers to check for tolerance
-        for seconds in vec![
+        for seconds in &[
             // We don't start at zero because times before the UNIX_EPOCH cannot be converted to
             // OscTime.
             OscTime::UNIX_OFFSET as u32,
@@ -337,12 +337,11 @@ mod tests {
             OscTime::UNIX_OFFSET as u32 + 2,
             OscTime::UNIX_OFFSET as u32 + 3,
             u32::MAX - 1,
-            u32::MAX,
-        ] {
+            u32::MAX] {
             let fractional_max = 100;
             for fractional in 0..fractional_max {
-                times.push((seconds, fractional));
-                times.push((seconds, fractional_max - fractional));
+                times.push((*seconds, fractional));
+                times.push((*seconds, fractional_max - fractional));
             }
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -303,7 +303,6 @@ impl<'a> From<&'a str> for OscMessage {
 }
 
 #[cfg(test)]
-#[allow(clippy::all)]
 mod tests {
     #[cfg(feature = "std")]
     use super::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -303,6 +303,7 @@ impl<'a> From<&'a str> for OscMessage {
 }
 
 #[cfg(test)]
+#[allow(clippy::all)]
 mod tests {
     #[cfg(feature = "std")]
     use super::*;

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -8,17 +8,15 @@ use rosc::address::Matcher;
 fn test_matcher() {
     let matcher = Matcher::new("/oscillator/[0-9]/*/pre[!1234?*]post/{frequency,phase}/x?")
         .expect("Matcher::new");
-    assert_eq!(
+    assert!(
         matcher
             .match_address("/oscillator/1/something/preXpost/phase/xy")
             .expect("should match"),
-        true
     );
-    assert_eq!(
-        matcher
+    assert!(
+        !matcher
             .match_address("/oscillator/1/something/pre1post/phase/xy")
             .expect("should not match"),
-        false
     );
     matcher.match_address("invalid_address").expect_err("should fail because address does not start with a slash");
 }

--- a/tests/decoder_test.rs
+++ b/tests/decoder_test.rs
@@ -124,8 +124,7 @@ fn test_decode_udp_args() {
         // array content
         .chain(i_bytes.iter())
         .chain(f_bytes.iter())
-        .chain(i_bytes.iter())
-        .map(|x| *x)
+        .chain(i_bytes.iter()).copied()
         .collect::<Vec<u8>>();
 
     let merged: Vec<u8> = addr

--- a/tests/decoder_test.rs
+++ b/tests/decoder_test.rs
@@ -2,7 +2,7 @@ extern crate byteorder;
 extern crate rosc;
 
 use byteorder::{BigEndian, ByteOrder};
-use std::mem;
+
 
 use rosc::{decoder, encoder, OscBundle, OscPacket, OscTime, OscType};
 
@@ -92,12 +92,12 @@ fn test_decode_udp_args() {
     assert_eq!(BigEndian::read_f64(&d_bytes), d);
 
     let i = 12345678i32;
-    let i_bytes: [u8; 4] = unsafe { mem::transmute(i.to_be()) };
+    let i_bytes: [u8; 4] = i.to_be().to_ne_bytes();
 
     let l = -1234567891011i64;
-    let h_bytes: [u8; 8] = unsafe { mem::transmute(l.to_be()) };
+    let h_bytes: [u8; 8] = l.to_be().to_ne_bytes();
 
-    let blob_size: [u8; 4] = unsafe { mem::transmute(6u32.to_be()) };
+    let blob_size: [u8; 4] = 6u32.to_be().to_ne_bytes();
     let blob: Vec<u8> = vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8];
 
     let s = "I am an osc test string.";
@@ -106,7 +106,7 @@ fn test_decode_udp_args() {
     let s_bytes: Vec<u8> = encoder::encode_string(s);
 
     let c = '$';
-    let c_bytes: [u8; 4] = unsafe { mem::transmute((c as u32).to_be()) };
+    let c_bytes: [u8; 4] = (c as u32).to_be().to_ne_bytes();
 
     let a = vec![OscType::Int(i), OscType::Float(f), OscType::Int(i)];
 

--- a/tests/decoder_test.rs
+++ b/tests/decoder_test.rs
@@ -75,6 +75,7 @@ fn test_decode_udp_empty_bundle() {
 }
 
 #[test]
+#[allow(clippy::approx_constant)]
 fn test_decode_udp_args() {
     // /another/valid/address/123 ,fdih 3.1415 3.14159265359 12345678i32
     // -1234567891011

--- a/tests/encoder_test.rs
+++ b/tests/encoder_test.rs
@@ -51,6 +51,7 @@ fn test_encode_empty_bundle() {
 }
 
 #[test]
+#[allow(clippy::approx_constant)]
 fn test_encode_message_with_args() {
     let msg_packet = OscPacket::Message(OscMessage {
         addr: "/another/address/1".to_string(),

--- a/tests/types_test.rs
+++ b/tests/types_test.rs
@@ -5,7 +5,7 @@ use rosc::{OscArray, OscType};
 #[test]
 fn test_osc_array_from_iter() {
     use std::iter::FromIterator;
-    let iter = (0..3).map(|i| OscType::Int(i));
+    let iter = (0..3).map(OscType::Int);
     let osc_arr = OscArray::from_iter(iter);
     assert_eq!(
         osc_arr,


### PR DESCRIPTION
Clippy produced broken code when applying the remaining fix:

        $ cargo clippy --fix
            Checking rosc v0.6.0 (/home/alinz/code/rosc)
        warning: failed to automatically apply fixes suggested by rustc to crate `rosc`
        
        after fixes were automatically applied the compiler reported errors within these files:
        
          * src/decoder.rs
        
        This likely indicates a bug in either rustc or cargo itself,
        and we would appreciate a bug report! You're likely to see
        a number of compiler warnings after this message which cargo
        attempted to fix but failed. If you could open an issue at
        https://github.com/rust-lang/rust/issues
        quoting the full output of this command we'd be very appreciative!
        Note that you may be able to make some more progress in the near-term
        fixing code with the `--broken-code` flag
        
        The following errors were reported:
        error[E0597]: `elem_size` does not live long enough
           --> src/decoder.rs:121:18
            |
        119 | /     map_parser(
        120 | |         |input| {
            | |         ------- value captured here
        121 | |             take(elem_size)(input).map_err(|_: nom::Err<OscError>| {
            | |                  ^^^^^^^^^ borrowed value does not live long enough
        122 | |                 nom::Err::Error(OscError::BadBundle(
        ...   |
        127 | |         |input| decode_packet(input, original_input),
        128 | |     )(input)
            | |_____- a temporary with access to the borrow is created here ...
        129 |   }
            |   -
            |   |
            |   `elem_size` dropped here while still borrowed
            |   ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `impl FnMut(&[u8])-> std::result::Result<(&[u8], types::OscPacket), nom::Err<errors::OscError>>`
            |
            = note: the temporary is part of an expression at the end of a block;
                    consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
        help: for example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block
            |
        119 ~     let x = map_parser(
        120 |         |input| {
        121 |             take(elem_size)(input).map_err(|_: nom::Err<OscError>| {
        122 |                 nom::Err::Error(OscError::BadBundle(
        123 |                     "Bundle shorter than expected!".to_string(),
        124 |                 ))
          ...
        
        error: aborting due to previous error
        
        For more information about this error, try `rustc --explain E0597`.
        Original diagnostics will follow.
        
        warning: returning the result of a `let` binding from a block
           --> src/decoder.rs:128:5
            |
        118 | /     let result = map_parser(
        119 | |         |input| {
        120 | |             take(elem_size)(input).map_err(|_: nom::Err<OscError>| {
        121 | |                 nom::Err::Error(OscError::BadBundle(
        ...   |
        126 | |         |input| decode_packet(input, original_input),
        127 | |     )(input);
            | |_____________- unnecessary `let` binding
        128 |       result
            |       ^^^^^^
            |
            = note: `#[warn(clippy::let_and_return)]` on by default
            = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return
        help: return the expression directly
            |
        118 ~
        119 ~     map_parser(
        120 +         |input| {
        121 +             take(elem_size)(input).map_err(|_: nom::Err<OscError>| {
        122 +                 nom::Err::Error(OscError::BadBundle(
        123 +                     "Bundle shorter than expected!".to_string(),
          ...
        
        warning: `rosc` (lib) generated 1 warning
        warning: `rosc` (lib test) generated 1 warning (1 duplicate)
            Finished dev [unoptimized + debuginfo] target(s) in 0.69s