### PR TITLE
Nom matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,10 @@ readme = "README.md"
 
 [features]
 lints = ["clippy"]
-std = ["regex"]
+std = []
 default = ["std"]
 
 [dependencies]
 byteorder = {version="1", default-features=false}
 nom = { git = "https://github.com/Geal/nom", default-features=false, features=["alloc"] }
 clippy = {version="^0", optional=true}
-regex = { version="1.5", optional=true}

--- a/src/address.rs
+++ b/src/address.rs
@@ -8,7 +8,7 @@ use nom::bytes::complete::{is_not, tag, take_till1, take, is_a, take_while1};
 use nom::character::complete::{char, satisfy};
 use nom::combinator::{all_consuming, complete, map_parser, verify};
 use nom::multi::{many1, separated_list0};
-use nom::sequence::{delimited, preceded, separated_pair};
+use nom::sequence::{delimited, pair, preceded, separated_pair};
 use nom::{IResult, Parser};
 use nom::error::{ErrorKind, ParseError};
 use regex::Regex;
@@ -336,5 +336,26 @@ fn match_wildcard<'a>(input: &'a str, minimum_length: usize, next: Option<&Addre
             }
             verify(take(longest), |s: &str| s.len() >= minimum_length)(input)
         }
+    }
+}
+
+/// Verify that an address is valid
+///
+/// # Examples
+/// ```
+/// use rosc::address::verify_address;
+///
+/// match verify_address("/oscillator/1") {
+///     Ok(()) => println!("Address is valid"),
+///     Err(e) => println!("Address is not valid")
+/// }
+/// ```
+pub fn verify_address(input: &str) -> Result<(), OscError>
+{
+    match all_consuming::<_,_,nom::error::Error<&str>,_>(
+        many1(pair(tag("/"), take_while1(is_address_character)))
+    )(input) {
+        Ok((a,b)) => Ok(()),
+        Err(_) => Err(OscError::BadAddress("Invalid address".to_string()))
     }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,17 +1,15 @@
 use crate::errors::OscError;
 
-use alloc::borrow::ToOwned;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use nom::branch::alt;
-use nom::bytes::complete::{is_not, tag, take_till1, take, is_a, take_while1};
+use nom::bytes::complete::{is_not, tag, take, is_a, take_while1};
 use nom::character::complete::{char, satisfy};
-use nom::combinator::{all_consuming, complete, map_parser, opt, recognize, verify};
-use nom::multi::{many1, separated_list0, separated_list1};
-use nom::sequence::{delimited, pair, preceded, separated_pair};
+use nom::combinator::{all_consuming, complete, opt, recognize, verify};
+use nom::multi::{many1, separated_list1};
+use nom::sequence::{delimited, pair, separated_pair};
 use nom::{IResult, Parser};
 use nom::error::{ErrorKind, ParseError};
-use regex::Regex;
 
 /// With a Matcher OSC method addresses can be [matched](Matcher::match_address) against an OSC address pattern.
 /// Refer to the OSC specification for details about OSC address spaces: <http://opensoundcontrol.org/spec-1_0.html#osc-address-spaces-and-osc-addresses>

--- a/src/address.rs
+++ b/src/address.rs
@@ -47,7 +47,7 @@ impl Matcher {
     /// Matcher::new("").expect_err("address does not start with a slash");
     /// ```
     pub fn new(pattern: &str) -> Result<Self, OscError> {
-        let pattern_parts = match all_consuming(many1(get_address_pattern_components))(pattern) {
+        let pattern_parts = match all_consuming(many1(map_address_pattern_component))(pattern) {
             Ok((_, parts)) => { parts }
             Err(_) => panic!("Address must be valid")
         };
@@ -229,7 +229,7 @@ enum AddressPatternComponent {
     Choice(Vec<String>),
 }
 
-fn get_address_pattern_components(input: &str) -> IResult<&str, AddressPatternComponent>
+fn map_address_pattern_component(input: &str) -> IResult<&str, AddressPatternComponent>
 {
     alt((
         // Anything that's alphanumeric gets matched literally
@@ -308,7 +308,7 @@ fn match_wildcard<'a>(input: &'a str, minimum_length: usize, next: Option<&Addre
                     AddressPatternComponent::Tag(s) => match_literally(substring, s.as_str()),
                     AddressPatternComponent::CharacterClass(cc) => match_character_class(substring, cc),
                     AddressPatternComponent::Choice(s) => match_choice(substring, s),
-                    // These two cases are prevented from happening by get_address_pattern_part
+                    // These two cases are prevented from happening by map_address_pattern_component
                     AddressPatternComponent::WildcardSingle => panic!("Single wildcard ('?') must not follow wildcard ('*')"),
                     AddressPatternComponent::Wildcard(_) => panic!("Double wildcards must be condensed into one"),
                 };

--- a/src/address.rs
+++ b/src/address.rs
@@ -183,6 +183,19 @@ fn expand_character_range<'a>(first: char, second: char) -> String {
     out
 }
 
+/// Removes all duplicates from a string of characters
+fn deduplicate_characters(input: String) -> String
+{
+    let mut out: String = String::from("");
+    for char in input.chars()
+    {
+        if !out.contains(char) {
+            out.push(char);
+        }
+    }
+    out
+}
+
 impl CharacterClass {
     pub fn new(s: &str) -> Self {
         let mut input = s;
@@ -207,8 +220,7 @@ impl CharacterClass {
         ))))(input);
 
         match characters {
-            // TODO: Deduplicate?
-            Ok((_, o)) => CharacterClass { negated, characters: o.concat() },
+            Ok((_, o)) => CharacterClass { negated, characters: deduplicate_characters(o.concat()) },
             _ => { panic!("Invalid character class formatting {}", s) }
         }
     }
@@ -238,7 +250,6 @@ fn map_address_pattern_component(input: &str) -> IResult<&str, AddressPatternCom
         // For example, '*??' must match at least 2 characters.
         is_a("*?").map(|x: &str| { AddressPatternComponent::Wildcard(x.matches("?").count()) }),
         pattern_choice.map(|choices: Vec<&str>| { AddressPatternComponent::Choice(choices.iter().map(|x| x.to_string()).collect()) }),
-        // TODO: prevent an empty character class, i.e. [!]
         pattern_character_class.map(|s: &str| { AddressPatternComponent::CharacterClass(CharacterClass::new(s)) })
     ))(input)
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -47,6 +47,7 @@ impl Matcher {
     /// Matcher::new("").expect_err("address does not start with a slash");
     /// ```
     pub fn new(pattern: &str) -> Result<Self, OscError> {
+        verify_address_pattern(pattern)?;
         let pattern_parts = match all_consuming(many1(map_address_pattern_component))(pattern) {
             Ok((_, parts)) => { parts }
             Err(_) => panic!("Address must be valid")

--- a/src/address.rs
+++ b/src/address.rs
@@ -34,8 +34,7 @@ impl Matcher {
     /// - `{foo,bar}` is an alternative, matching either `foo` or `bar`
     /// - everything else is matched literally
     ///
-    /// Refer to the OSC specification for detaiWhat it does
-
+    /// Refer to the OSC specification for details about address pattern matching: <osc-message-dispatching-and-pattern-matching>.
     ///
     /// # Examples
     ///

--- a/src/address.rs
+++ b/src/address.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use std::collections::HashSet;
 use std::iter::FromIterator;
 use nom::branch::alt;
-use nom::bytes::complete::{is_a, is_not, tag, take, take_while1};
+use nom::bytes::complete::{is_a, is_not, tag, take, take_while1, take_while_m_n};
 use nom::character::complete::{char, satisfy};
 use nom::combinator::{all_consuming, complete, opt, recognize, verify};
 use nom::error::{ErrorKind, ParseError};
@@ -267,8 +267,7 @@ fn match_literally<'a>(input: &'a str, pattern: &str) -> IResult<&'a str, &'a st
 }
 
 fn match_wildcard_single(input: &str) -> IResult<&str, &str> {
-    // TODO: this has to be possible with a simpler parser?
-    verify(take(1usize), |s: &str| s.chars().all(is_address_character))(input)
+    take_while_m_n(1, 1, is_address_character)(input)
 }
 
 fn match_character_class<'a>(

--- a/src/address.rs
+++ b/src/address.rs
@@ -159,6 +159,15 @@ fn parse_address_pattern(input: &str) -> Result<Vec<Regex>, OscError> {
         .map_err(|err| OscError::RegexError(err.to_string()))
 }
 
+/// Check whether a character is an allowed address character
+/// All printable ASCII characters except for a few special characters are allowed
+fn is_address_character(x: char) -> bool {
+    match x {
+        ' ' | '#' | '*' | ',' | '/' | '?' | '[' | ']' | '{' | '}' => false,
+        c => c > '\x20' && c < '\x7F'
+    }
+}
+
 /// A characters class is defined by a set or range of characters that it matches.
 /// For example, [a-z] matches all lowercase alphabetic letters. It can also contain multiple
 /// ranges, like [a-zA-Z]. Instead of a range you can also directly provide the characters to match,
@@ -193,15 +202,6 @@ fn expand_character_range<'a>(first: char, second: char) -> String {
         }
     }
     out
-}
-
-/// Check whether a character is an allowed address character
-/// All printable ASCII characters except for a few special characters are allowed
-fn is_address_character(x: char) -> bool {
-    match x {
-        ' ' | '#' | '*' | ',' | '/' | '?' | '[' | ']' | '{' | '}' => false,
-        c => c > '\x20' && c < '\x7F'
-    }
 }
 
 impl CharacterClass {

--- a/src/address.rs
+++ b/src/address.rs
@@ -123,10 +123,11 @@ impl Matcher {
 /// Check whether a character is an allowed address character
 /// All printable ASCII characters except for a few special characters are allowed
 fn is_address_character(x: char) -> bool {
-    match x {
-        ' ' | '#' | '*' | ',' | '/' | '?' | '[' | ']' | '{' | '}' => false,
-        c => c > '\x20' && c < '\x7F',
+    if !x.is_ascii() || x.is_ascii_control() {
+        return false
     }
+
+    return ![' ', '#', '*', ',', '/', '?', '[', ']', '{', '}'].contains(&x)
 }
 
 /// Parser to turn a choice like '{foo,bar}' into a vector containing the choices, like ["foo", "bar"]

--- a/src/address.rs
+++ b/src/address.rs
@@ -275,7 +275,7 @@ fn match_literally<'a>(input: &'a str, pattern: &str) -> IResult<&'a str, &'a st
 fn match_wildcard_single(input: &str) -> IResult<&str, &str>
 {
     // TODO: this has to be possible with a simpler parser?
-    verify(take(1usize), |s: &str| s.chars().all(char::is_alphanumeric))(input)
+    verify(take(1usize), |s: &str| s.chars().all(is_address_character))(input)
 }
 
 fn match_character_class<'a>(input: &'a str, character_class: &'a CharacterClass) -> IResult<&'a str, &'a str> {

--- a/src/address.rs
+++ b/src/address.rs
@@ -187,9 +187,11 @@ fn expand_character_range<'a>(first: char, second: char) -> String {
 
     let mut out = String::from("");
     for c in range {
-        out.push(c as char);
+        // For funky ranges like [0-a], some illegal characters are contained
+        if is_address_character(c as char) {
+            out.push(c as char);
+        }
     }
-    // TODO: for funky but legal ranges like '0-a' we need to clean up the ranges
     out
 }
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -48,11 +48,8 @@ impl Matcher {
     /// ```
     pub fn new(pattern: &str) -> Result<Self, OscError> {
         verify_address_pattern(pattern)?;
-        let pattern_parts = match all_consuming(many1(map_address_pattern_component))(pattern) {
-            Ok((_, parts)) => parts,
-            // This should never happen because pattern is verified above
-            Err(_) => panic!("Address pattern must be valid"),
-        };
+        let mut match_fn = all_consuming(many1(map_address_pattern_component));
+        let (_, pattern_parts) = match_fn(pattern).map_err(|err| OscError::BadAddressPattern(err.to_string()))?;
 
         Ok(Matcher {
             pattern: pattern.into(),

--- a/src/address.rs
+++ b/src/address.rs
@@ -159,6 +159,12 @@ fn parse_address_pattern(input: &str) -> Result<Vec<Regex>, OscError> {
         .map_err(|err| OscError::RegexError(err.to_string()))
 }
 
+/// A characters class is defined by a set or range of characters that it matches.
+/// For example, [a-z] matches all lowercase alphabetic letters. It can also contain multiple
+/// ranges, like [a-zA-Z]. Instead of a range you can also directly provide the characters to match,
+/// e.g. [abc123]. You can also combine this with ranges, like [a-z123].
+/// If the first characters is an exclamation point, the match is negated, e.g. [!0-9] will match
+/// anything except numbers.
 #[derive(Debug)]
 struct CharacterClass {
     pub negated: bool,
@@ -166,6 +172,8 @@ struct CharacterClass {
 }
 
 /// Expand a character range like 'a-d' to all the letters contained in the range, e.g. 'abcd'
+/// This is done by converting the characters to their ASCII values and then getting every ASCII
+/// in between.
 fn expand_character_range<'a>(first: char, second: char) -> String {
     let start = first as u8;
     let end = second as u8;

--- a/src/address.rs
+++ b/src/address.rs
@@ -273,7 +273,7 @@ fn match_character_class<'a>(
     }
 }
 
-/// Try all the tags in a choice element
+/// Sequentially try all tags from choice element until one matches or return an error
 /// Example choice element: '{foo,bar}'
 /// It will get parsed into a vector containing the strings "foo" and "bar", which are then matched
 fn match_choice<'a>(input: &'a str, choices: &[String]) -> IResult<&'a str, &'a str> {

--- a/src/address.rs
+++ b/src/address.rs
@@ -53,7 +53,7 @@ impl Matcher {
         };
 
         Ok(Matcher {
-            pattern: String::from(pattern),
+            pattern: pattern.into(),
             pattern_parts,
         })
     }

--- a/src/address.rs
+++ b/src/address.rs
@@ -2,6 +2,8 @@ use crate::errors::OscError;
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use std::collections::HashSet;
+use std::iter::FromIterator;
 use nom::branch::alt;
 use nom::bytes::complete::{is_a, is_not, tag, take, take_while1};
 use nom::character::complete::{char, satisfy};
@@ -183,17 +185,6 @@ fn expand_character_range(first: char, second: char) -> String {
     out
 }
 
-/// Removes all duplicates from a string of characters
-fn deduplicate_characters(input: String) -> String {
-    let mut out: String = String::from("");
-    for char in input.chars() {
-        if !out.contains(char) {
-            out.push(char);
-        }
-    }
-    out
-}
-
 impl CharacterClass {
     pub fn new(s: &str) -> Self {
         let mut input = s;
@@ -225,7 +216,7 @@ impl CharacterClass {
         match characters {
             Ok((_, o)) => CharacterClass {
                 negated,
-                characters: deduplicate_characters(o.concat()),
+                characters: HashSet::<char>::from_iter(o.concat().chars()).iter().collect(),
             },
             _ => {
                 panic!("Invalid character class formatting {}", s)

--- a/src/address.rs
+++ b/src/address.rs
@@ -167,11 +167,7 @@ fn expand_character_range(first: char, second: char) -> String {
     let start = first as u8;
     let end = second as u8;
 
-    let range = if start >= end {
-        end..=start
-    } else {
-        start..=end
-    };
+    let range = start..=end;
 
     range
         .into_iter()

--- a/src/address.rs
+++ b/src/address.rs
@@ -3,13 +3,13 @@ use crate::errors::OscError;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use nom::branch::alt;
-use nom::bytes::complete::{is_not, tag, take, is_a, take_while1};
+use nom::bytes::complete::{is_a, is_not, tag, take, take_while1};
 use nom::character::complete::{char, satisfy};
 use nom::combinator::{all_consuming, complete, opt, recognize, verify};
+use nom::error::{ErrorKind, ParseError};
 use nom::multi::{many1, separated_list1};
 use nom::sequence::{delimited, pair, separated_pair};
 use nom::{IResult, Parser};
-use nom::error::{ErrorKind, ParseError};
 
 /// With a Matcher OSC method addresses can be [matched](Matcher::match_address) against an OSC address pattern.
 /// Refer to the OSC specification for details about OSC address spaces: <http://opensoundcontrol.org/spec-1_0.html#osc-address-spaces-and-osc-addresses>
@@ -34,7 +34,8 @@ impl Matcher {
     /// - `{foo,bar}` is an alternative, matching either `foo` or `bar`
     /// - everything else is matched literally
     ///
-    /// Refer to the OSC specification for details about address pattern matching: <osc-message-dispatching-and-pattern-matching>.
+    /// Refer to the OSC specification for detaiWhat it does
+
     ///
     /// # Examples
     ///
@@ -47,12 +48,15 @@ impl Matcher {
     pub fn new(pattern: &str) -> Result<Self, OscError> {
         verify_address_pattern(pattern)?;
         let pattern_parts = match all_consuming(many1(map_address_pattern_component))(pattern) {
-            Ok((_, parts)) => { parts }
+            Ok((_, parts)) => parts,
             // This should never happen because pattern is verified above
-            Err(_) => panic!("Address pattern must be valid")
+            Err(_) => panic!("Address pattern must be valid"),
         };
 
-        Ok(Matcher { pattern: String::from(pattern), pattern_parts })
+        Ok(Matcher {
+            pattern: String::from(pattern),
+            pattern_parts,
+        })
     }
 
     /// Match an OSC address against an address pattern.
@@ -73,7 +77,8 @@ impl Matcher {
     /// assert_eq!(matcher.match_address("/oscillator/4/detune").unwrap(), false);
     /// ```
     pub fn match_address(&self, address: &str) -> Result<bool, OscError> {
-        verify_address(address)?;   // TODO: Create an address struct so we don't have to re-check addresses every time we match
+        verify_address(address)?; // TODO: Create an address struct so we don't have to re-check addresses every time we match
+
         // Trivial case
         if address == self.pattern {
             return Ok(true);
@@ -90,8 +95,10 @@ impl Matcher {
                         let next = &self.pattern_parts[index + 1];
                         match next {
                             // If the next component is a '/', there are no more components in the current part and it can be wholly consumed
-                            AddressPatternComponent::Tag(s) if s == "/" => match_wildcard(remainder, l.clone(), None),
-                            _ => match_wildcard(remainder, l.clone(), Some(next))
+                            AddressPatternComponent::Tag(s) if s == "/" => {
+                                match_wildcard(remainder, l.clone(), None)
+                            }
+                            _ => match_wildcard(remainder, l.clone(), Some(next)),
                         }
                     } else {
                         match_wildcard(remainder, l.clone(), None)
@@ -103,7 +110,7 @@ impl Matcher {
 
             match result {
                 Ok((i, _)) => remainder = i,
-                Err(_) => return Ok(false)  // Component didn't match, goodbye
+                Err(_) => return Ok(false), // Component didn't match, goodbye
             };
         }
 
@@ -121,29 +128,30 @@ impl Matcher {
 fn is_address_character(x: char) -> bool {
     match x {
         ' ' | '#' | '*' | ',' | '/' | '?' | '[' | ']' | '{' | '}' => false,
-        c => c > '\x20' && c < '\x7F'
+        c => c > '\x20' && c < '\x7F',
     }
 }
 
 /// Parser to turn a choice like '{foo,bar}' into a vector containing the choices, like ["foo", "bar"]
-fn pattern_choice(input: &str) -> IResult<&str, Vec<&str>>
-{
-    delimited(char('{'), separated_list1(tag(","), take_while1(is_address_character)), char('}'))(input)
+fn pattern_choice(input: &str) -> IResult<&str, Vec<&str>> {
+    delimited(
+        char('{'),
+        separated_list1(tag(","), take_while1(is_address_character)),
+        char('}'),
+    )(input)
 }
 
 /// Parser to recognize a character class like [!a-zA-Z] and return '!a-zA-Z'
-fn pattern_character_class(input: &str) -> IResult<&str, &str>
-{
+fn pattern_character_class(input: &str) -> IResult<&str, &str> {
     let inner = pair(
         // It is important to read the leading negating '!' to make sure the rest of the parsed
         // character class isn't empty. E.g. '[!]' is not a valid character class.
         recognize(opt(tag("!"))),
-        take_while1(is_address_character)
+        take_while1(is_address_character),
     );
 
-    delimited(char('['), recognize(inner) , char(']'))(input)
+    delimited(char('['), recognize(inner), char(']'))(input)
 }
-
 
 /// A characters class is defined by a set or range of characters that it matches.
 /// For example, [a-z] matches all lowercase alphabetic letters. It can also contain multiple
@@ -182,11 +190,9 @@ fn expand_character_range<'a>(first: char, second: char) -> String {
 }
 
 /// Removes all duplicates from a string of characters
-fn deduplicate_characters(input: String) -> String
-{
+fn deduplicate_characters(input: String) -> String {
     let mut out: String = String::from("");
-    for char in input.chars()
-    {
+    for char in input.chars() {
         if !out.contains(char) {
             out.push(char);
         }
@@ -203,23 +209,33 @@ impl CharacterClass {
                 negated = true;
                 input = i;
             }
-            Err(_) => negated = false
+            Err(_) => negated = false,
         }
 
         let characters = complete(many1(alt((
             // '!' besides at beginning has no special meaning, but is legal
             char::<_, nom::error::Error<&str>>('!').map(|_| String::from("")),
             // attempt to match a range like a-z or 0-9
-            separated_pair(satisfy(is_address_character), char('-'), satisfy(is_address_character)).map(|(first, second)| expand_character_range(first, second)),
+            separated_pair(
+                satisfy(is_address_character),
+                char('-'),
+                satisfy(is_address_character),
+            )
+            .map(|(first, second)| expand_character_range(first, second)),
             // Match characters literally
             satisfy(is_address_character).map(|x| x.to_string()),
             // Trailing dash
-            char('-').map(|_| { String::from("-") })
+            char('-').map(|_| String::from("-")),
         ))))(input);
 
         match characters {
-            Ok((_, o)) => CharacterClass { negated, characters: deduplicate_characters(o.concat()) },
-            _ => { panic!("Invalid character class formatting {}", s) }
+            Ok((_, o)) => CharacterClass {
+                negated,
+                characters: deduplicate_characters(o.concat()),
+            },
+            _ => {
+                panic!("Invalid character class formatting {}", s)
+            }
         }
     }
 }
@@ -233,37 +249,41 @@ enum AddressPatternComponent {
     Choice(Vec<String>),
 }
 
-fn map_address_pattern_component(input: &str) -> IResult<&str, AddressPatternComponent>
-{
+fn map_address_pattern_component(input: &str) -> IResult<&str, AddressPatternComponent> {
     alt((
         // Anything that's alphanumeric gets matched literally
-        take_while1(is_address_character).map(|s: &str| { AddressPatternComponent::Tag(String::from(s)) }),
+        take_while1(is_address_character)
+            .map(|s: &str| AddressPatternComponent::Tag(String::from(s))),
         // Slashes must be seperated into their own tag for the non-greedy implementation of wildcards
-        char('/').map(|c: char| { AddressPatternComponent::Tag(c.to_string()) }),
-        tag("?").map(|_| { AddressPatternComponent::WildcardSingle }),
+        char('/').map(|c: char| AddressPatternComponent::Tag(c.to_string())),
+        tag("?").map(|_| AddressPatternComponent::WildcardSingle),
         // Combinations of wildcards are a bit tricky.
         // Multiple '*' wildcards in a row are equal to a single '*'.
         // A '*' wildcard followed by any number of '?' wildcards is also equal to '*' but must
         // match at least the same amount of characters as there are '?' wildcards in the combination.
         // For example, '*??' must match at least 2 characters.
-        is_a("*?").map(|x: &str| { AddressPatternComponent::Wildcard(x.matches("?").count()) }),
-        pattern_choice.map(|choices: Vec<&str>| { AddressPatternComponent::Choice(choices.iter().map(|x| x.to_string()).collect()) }),
-        pattern_character_class.map(|s: &str| { AddressPatternComponent::CharacterClass(CharacterClass::new(s)) })
+        is_a("*?").map(|x: &str| AddressPatternComponent::Wildcard(x.matches("?").count())),
+        pattern_choice.map(|choices: Vec<&str>| {
+            AddressPatternComponent::Choice(choices.iter().map(|x| x.to_string()).collect())
+        }),
+        pattern_character_class
+            .map(|s: &str| AddressPatternComponent::CharacterClass(CharacterClass::new(s))),
     ))(input)
 }
 
-fn match_literally<'a>(input: &'a str, pattern: &str) -> IResult<&'a str, &'a str>
-{
+fn match_literally<'a>(input: &'a str, pattern: &str) -> IResult<&'a str, &'a str> {
     tag(pattern)(input)
 }
 
-fn match_wildcard_single(input: &str) -> IResult<&str, &str>
-{
+fn match_wildcard_single(input: &str) -> IResult<&str, &str> {
     // TODO: this has to be possible with a simpler parser?
     verify(take(1usize), |s: &str| s.chars().all(is_address_character))(input)
 }
 
-fn match_character_class<'a>(input: &'a str, character_class: &'a CharacterClass) -> IResult<&'a str, &'a str> {
+fn match_character_class<'a>(
+    input: &'a str,
+    character_class: &'a CharacterClass,
+) -> IResult<&'a str, &'a str> {
     if character_class.negated {
         is_not(character_class.characters.as_str())(input)
     } else {
@@ -275,29 +295,36 @@ fn match_character_class<'a>(input: &'a str, character_class: &'a CharacterClass
 /// Example choice element: '{foo,bar}'
 /// It will get parsed into a vector containing the strings "foo" and "bar", which are then matched
 fn match_choice<'a>(input: &'a str, choices: &Vec<String>) -> IResult<&'a str, &'a str> {
-    for choice in choices
-    {
+    for choice in choices {
         match tag::<_, _, nom::error::Error<&str>>(choice.as_str())(input) {
             Ok((i, o)) => return Ok((i, o)),
             Err(_) => {}
         }
     }
-    return Err(nom::Err::Error(nom::error::Error::from_error_kind(input, ErrorKind::Tag)));
+    return Err(nom::Err::Error(nom::error::Error::from_error_kind(
+        input,
+        ErrorKind::Tag,
+    )));
 }
 
 /// Match Wildcard '*' by either consuming the rest of the part, or, if it's not the last component
 /// in the part, by looking ahead and matching the next component
-fn match_wildcard<'a>(input: &'a str, minimum_length: usize, next: Option<&AddressPatternComponent>) -> IResult<&'a str, &'a str>
-{
+fn match_wildcard<'a>(
+    input: &'a str,
+    minimum_length: usize,
+    next: Option<&AddressPatternComponent>,
+) -> IResult<&'a str, &'a str> {
     match next {
         // No next component, consume all allowed characters until end or next '/'
-        None => verify(take_while1(is_address_character), |s: &str| s.len() >= minimum_length)(input),
+        None => verify(take_while1(is_address_character), |s: &str| {
+            s.len() >= minimum_length
+        })(input),
         // There is another element in this part, so logic gets a bit more complicated
         Some(component) => {
             // Wildcards can only match within the current address part, discard the rest
             let address_part = match input.split_once("/") {
                 Some((p, _)) => p,
-                None => input
+                None => input,
             };
 
             // Attempt to find the latest matching occurrence of the next pattern component
@@ -307,11 +334,17 @@ fn match_wildcard<'a>(input: &'a str, minimum_length: usize, next: Option<&Addre
                 let (_, substring) = input.split_at(i);
                 let result: IResult<_, _, nom::error::Error<&str>> = match component {
                     AddressPatternComponent::Tag(s) => match_literally(substring, s.as_str()),
-                    AddressPatternComponent::CharacterClass(cc) => match_character_class(substring, cc),
+                    AddressPatternComponent::CharacterClass(cc) => {
+                        match_character_class(substring, cc)
+                    }
                     AddressPatternComponent::Choice(s) => match_choice(substring, s),
                     // These two cases are prevented from happening by map_address_pattern_component
-                    AddressPatternComponent::WildcardSingle => panic!("Single wildcard ('?') must not follow wildcard ('*')"),
-                    AddressPatternComponent::Wildcard(_) => panic!("Double wildcards must be condensed into one"),
+                    AddressPatternComponent::WildcardSingle => {
+                        panic!("Single wildcard ('?') must not follow wildcard ('*')")
+                    }
+                    AddressPatternComponent::Wildcard(_) => {
+                        panic!("Double wildcards must be condensed into one")
+                    }
                 };
 
                 match result {
@@ -335,27 +368,26 @@ fn match_wildcard<'a>(input: &'a str, minimum_length: usize, next: Option<&Addre
 ///     Err(e) => println!("Address is not valid")
 /// }
 /// ```
-pub fn verify_address(input: &str) -> Result<(), OscError>
-{
-    match all_consuming::<_,_,nom::error::Error<&str>,_>(
-        many1(pair(tag("/"), take_while1(is_address_character)))
-    )(input) {
-        Ok((_)) => Ok(()),
-        Err(_) => Err(OscError::BadAddress("Invalid address".to_string()))
+pub fn verify_address(input: &str) -> Result<(), OscError> {
+    match all_consuming::<_, _, nom::error::Error<&str>, _>(many1(pair(
+        tag("/"),
+        take_while1(is_address_character),
+    )))(input)
+    {
+        Ok(_) => Ok(()),
+        Err(_) => Err(OscError::BadAddress("Invalid address".to_string())),
     }
 }
 
 /// Parse an address pattern's part until the next '/' or the end
 fn address_pattern_part_parser(input: &str) -> IResult<&str, Vec<&str>> {
-    many1::<_, _, nom::error::Error<&str>, _>(
-        alt((
-            take_while1(is_address_character),
-            tag("?"),
-            tag("*"),
-            recognize(pattern_choice),
-            pattern_character_class,
-        ))
-    )(input)
+    many1::<_, _, nom::error::Error<&str>, _>(alt((
+        take_while1(is_address_character),
+        tag("?"),
+        tag("*"),
+        recognize(pattern_choice),
+        pattern_character_class,
+    )))(input)
 }
 
 /// Verify that an address pattern is valid
@@ -369,17 +401,13 @@ fn address_pattern_part_parser(input: &str) -> IResult<&str, Vec<&str>> {
 ///     Err(e) => println!("Address is not valid")
 /// }
 /// ```
-pub fn verify_address_pattern(input: &str) -> Result<(), OscError>
-{
+pub fn verify_address_pattern(input: &str) -> Result<(), OscError> {
     match all_consuming(many1(
         // Each part must start with a '/'. This automatically also prevents a trailing '/'
-        pair(
-            tag("/"),
-            address_pattern_part_parser.map(|x| x.concat()),
-        )
+        pair(tag("/"), address_pattern_part_parser.map(|x| x.concat())),
     ))(input)
     {
-        Ok((_)) => Ok(()),
-        Err(_) => Err(OscError::BadAddress("Invalid address pattern".to_string()))
+        Ok(_) => Ok(()),
+        Err(_) => Err(OscError::BadAddress("Invalid address pattern".to_string())),
     }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -114,11 +114,7 @@ impl Matcher {
         }
 
         // Address is only matched if it was consumed entirely
-        if remainder.is_empty() {
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+        Ok(remainder.is_empty())
     }
 }
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -175,14 +175,11 @@ fn expand_character_range(first: char, second: char) -> String {
         start..=end
     };
 
-    let mut out = String::from("");
-    for c in range {
-        // For funky ranges like [0-a], some illegal characters are contained
-        if is_address_character(c as char) {
-            out.push(c as char);
-        }
-    }
-    out
+    range
+        .into_iter()
+        .map(char::from)
+        .filter(|c| is_address_character(*c))
+        .collect()
 }
 
 impl CharacterClass {

--- a/src/address.rs
+++ b/src/address.rs
@@ -4,23 +4,24 @@ use alloc::borrow::ToOwned;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use nom::branch::alt;
-use nom::bytes::complete::{is_not, tag, take_till1};
-use nom::character::complete::char;
-use nom::combinator::{all_consuming, map_parser};
-use nom::multi::many1;
-use nom::sequence::{delimited, preceded};
+use nom::bytes::complete::{is_not, tag, take_till1, take, is_a};
+use nom::character::complete::{alphanumeric1, char, satisfy};
+use nom::combinator::{all_consuming, complete, map_parser, verify};
+use nom::multi::{many1, separated_list0};
+use nom::sequence::{delimited, preceded, separated_pair};
 use nom::{IResult, Parser};
+use nom::error::{ErrorKind, ParseError};
 use regex::Regex;
 
 /// With a Matcher OSC method addresses can be [matched](Matcher::match_address) against an OSC address pattern.
 /// Refer to the OSC specification for details about OSC address spaces: <http://opensoundcontrol.org/spec-1_0.html#osc-address-spaces-and-osc-addresses>
 #[derive(Debug)]
 pub struct Matcher {
-    res: Vec<Regex>,
+    pub pattern: String,
+    pattern_parts: Vec<AddressPatternComponent>,
 }
 
 impl Matcher {
-
     /// Instantiates a new `Matcher` with the given address pattern.
     /// An error will be returned if the given address pattern is invalid.
     ///
@@ -46,8 +47,12 @@ impl Matcher {
     /// Matcher::new("").expect_err("address does not start with a slash");
     /// ```
     pub fn new(pattern: &str) -> Result<Self, OscError> {
-        let res = parse_address_pattern(pattern)?;
-        Ok(Matcher { res })
+        let pattern_parts = match all_consuming(many1(get_address_pattern_components))(pattern) {
+            Ok((_, parts)) => { parts }
+            Err(_) => panic!("Address must be valid")
+        };
+
+        Ok(Matcher { pattern: String::from(pattern), pattern_parts })
     }
 
     /// Match an OSC address against an address pattern.
@@ -68,16 +73,38 @@ impl Matcher {
     /// assert_eq!(matcher.match_address("/oscillator/4/detune").unwrap(), false);
     /// ```
     pub fn match_address(&self, address: &str) -> Result<bool, OscError> {
-        let (_, parts) = all_consuming(many1(parse_address_part))(address)
-            .map_err(|_| OscError::BadAddress("bad address".to_string()))?;
-        if parts.len() != self.res.len() {
-            return Ok(false);
+        let mut remainder: &str = address;
+        for (index, part) in self.pattern_parts.as_slice().iter().enumerate() {
+            let result = match part {
+                AddressPatternComponent::Tag(s) => match_literally(remainder, s.as_str()),
+                AddressPatternComponent::WildcardSingle => match_wildcard_single(remainder),
+                AddressPatternComponent::Wildcard(l) => {
+                    // Check if this is the last pattern component
+                    if index < self.pattern_parts.len() - 1 {
+                        let next = &self.pattern_parts[index + 1];
+                        match next {
+                            // If the next component is a '/', there are no more components in the current part and it can be wholly consumed
+                            AddressPatternComponent::Tag(s) if s == "/" => match_wildcard(remainder, l.clone(), None),
+                            _ => match_wildcard(remainder, l.clone(), Some(next))
+                        }
+                    } else {
+                        match_wildcard(remainder, l.clone(), None)
+                    }
+                }
+                AddressPatternComponent::CharacterClass(cc) => match_character_class(remainder, cc),
+                AddressPatternComponent::Choice(s) => match_choice(remainder, s),
+            };
+
+            match result {
+                Ok((i, _)) => remainder = i,
+                Err(_) => return Err(OscError::Unimplemented) // TODO
+            };
         }
-        Ok(self
-            .res
-            .iter()
-            .zip(parts)
-            .all(|(re, part)| re.is_match(part)))
+        return if remainder.len() == 0 {
+            Ok(true)
+        } else {
+            Err(OscError::Unimplemented)     // TODO
+        };
     }
 }
 
@@ -130,4 +157,168 @@ fn parse_address_pattern(input: &str) -> Result<Vec<Regex>, OscError> {
         .map(|p| Regex::new(p))
         .collect::<Result<Vec<Regex>, regex::Error>>()
         .map_err(|err| OscError::RegexError(err.to_string()))
+}
+
+#[derive(Debug)]
+struct CharacterClass {
+    pub negated: bool,
+    pub characters: String,
+}
+
+/// Expand a character range like 'a-d' to all the letters contained in the range, e.g. 'abcd'
+fn expand_character_range<'a>(first: char, second: char) -> String {
+    let start = first as u8;
+    let end = second as u8;
+
+    let range;
+    if start >= end {
+        range = end..=start;
+    } else {
+        range = start..=end;
+    }
+
+    let mut out = String::from("");
+    for c in range {
+        out.push(c as char);
+    }
+    // TODO: for funky but legal ranges like '0-a' we need to clean up the ranges
+    out
+}
+
+fn is_alphanumeric_char(x: char) -> bool {
+    x.is_alphanumeric()
+}
+
+impl CharacterClass {
+    pub fn new(s: &str) -> Self {
+        let mut input = s;
+        let negated;
+        match char::<_, nom::error::Error<&str>>('!')(input) {
+            Ok((i, _)) => {
+                negated = true;
+                input = i;
+            }
+            Err(_) => negated = false
+        }
+
+        let characters = complete(many1(alt((
+            // '!' besides at beginning has no special meaning, but is legal
+            char::<_, nom::error::Error<&str>>('!').map(|_| String::from("")),
+            // attempt to match a range like a-z or 0-9
+            separated_pair(satisfy(is_alphanumeric_char), char('-'), satisfy(is_alphanumeric_char)).map(|(first, second)| expand_character_range(first, second)),
+            // Match characters literally
+            satisfy(is_alphanumeric_char).map(|x| x.to_string()),
+            // Trailing dash
+            char('-').map(|_| { String::from("-") })
+        ))))(input);
+
+        match characters {
+            // TODO: Deduplicate?
+            Ok((_, o)) => CharacterClass { negated, characters: o.concat() },
+            _ => { panic!("Invalid character class formatting {}", s) }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum AddressPatternComponent {
+    Tag(String),
+    Wildcard(usize),
+    WildcardSingle,
+    CharacterClass(CharacterClass),
+    Choice(Vec<String>),
+}
+
+fn get_address_pattern_components(input: &str) -> IResult<&str, AddressPatternComponent>
+{
+    alt((
+        // Anything that's alphanumeric gets matched literally
+        alphanumeric1.map(|s: &str| { AddressPatternComponent::Tag(String::from(s)) }), // TODO: this should be all printable ascii characters, not just alphanum!
+        // Slashes must be seperated into their own tag for the non-greedy implementation of wildcards
+        char('/').map(|c: char| { AddressPatternComponent::Tag(c.to_string()) }),
+        tag("?").map(|_| { AddressPatternComponent::WildcardSingle }),
+        // Combinations of wildcards are a bit tricky.
+        // Multiple '*' wildcards in a row are equal to a single '*'.
+        // A '*' wildcard followed by any number of '?' wildcards is also equal to '*' but must
+        // match at least the same amount of characters as there are '?' wildcards in the combination.
+        // For example, '*??' must match at least 2 characters.
+        is_a("*?").map(|x: &str| { AddressPatternComponent::Wildcard(x.matches("?").count()) }),
+        map_parser(
+            delimited(char('{'), is_not("}"), char('}')),
+            separated_list0(char(','.into()), alphanumeric1),
+        ).map(|alternatives: Vec<&str>| { AddressPatternComponent::Choice(alternatives.iter().map(|x| x.to_string()).collect()) }),
+        delimited(char('['), is_not("]") /*TODO: Only allowed: alphanum and '!-' */, char(']')).map(|s: &str| { AddressPatternComponent::CharacterClass(CharacterClass::new(s)) })
+    ))(input)
+}
+
+fn match_literally<'a>(input: &'a str, pattern: &str) -> IResult<&'a str, &'a str>
+{
+    tag(pattern)(input)
+}
+
+fn match_wildcard_single(input: &str) -> IResult<&str, &str>
+{
+    // TODO: this has to be possible with a simpler parser?
+    verify(take(1usize), |s: &str| s.chars().all(char::is_alphanumeric))(input)
+}
+
+fn match_character_class<'a>(input: &'a str, character_class: &'a CharacterClass) -> IResult<&'a str, &'a str> {
+    if character_class.negated {
+        is_not(character_class.characters.as_str())(input)
+    } else {
+        is_a(character_class.characters.as_str())(input)
+    }
+}
+
+/// Try all the tags in a choice element
+/// Example choice element: '{foo,bar}'
+/// It will get parsed into a vector containing the strings "foo" and "bar", which are then matched
+fn match_choice<'a>(input: &'a str, choices: &Vec<String>) -> IResult<&'a str, &'a str> {
+    for choice in choices
+    {
+        match tag::<_, _, nom::error::Error<&str>>(choice.as_str())(input) {
+            Ok((i, o)) => return Ok((i, o)),
+            Err(_) => {}
+        }
+    }
+    return Err(nom::Err::Error(nom::error::Error::from_error_kind(input, ErrorKind::Tag)));
+}
+
+/// Match Wildcard '*' by either consuming the rest of the part, or, if it's not the last component
+/// in the part, by looking ahead and matching the next component
+fn match_wildcard<'a>(input: &'a str, minimum_length: usize, next: Option<&AddressPatternComponent>) -> IResult<&'a str, &'a str>
+{
+    match next {
+        // No next component, consume all alphanumeric characters until end or next '/'
+        None => verify(alphanumeric1, |s: &str| s.len() >= minimum_length)(input),
+        // There is another element in this part, so logic gets a bit more complicated
+        Some(component) => {
+            // Wildcards can only match within the current address part, discard the rest
+            let address_part = match input.split_once("/") {
+                Some((p, _)) => p,
+                None => input
+            };
+
+            // Attempt to find the latest matching occurrence of the next pattern component
+            // This is a greedy wildcard implementation
+            let mut longest: usize = 0;
+            for i in 0..address_part.len() {
+                let (_, substring) = input.split_at(i);
+                let result: IResult<_, _, nom::error::Error<&str>> = match component {
+                    AddressPatternComponent::Tag(s) => match_literally(substring, s.as_str()),
+                    AddressPatternComponent::CharacterClass(cc) => match_character_class(substring, cc),
+                    AddressPatternComponent::Choice(s) => match_choice(substring, s),
+                    // These two cases are prevented from happening by get_address_pattern_part
+                    AddressPatternComponent::WildcardSingle => panic!("Single wildcard ('?') must not follow wildcard ('*')"),
+                    AddressPatternComponent::Wildcard(_) => panic!("Double wildcards must be condensed into one"),
+                };
+
+                match result {
+                    Ok(_) => longest = i,
+                    _ => {}
+                }
+            }
+            verify(take(longest), |s: &str| s.len() >= minimum_length)(input)
+        }
+    }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -193,8 +193,13 @@ fn expand_character_range<'a>(first: char, second: char) -> String {
     out
 }
 
-fn is_alphanumeric_char(x: char) -> bool {
-    x.is_alphanumeric()
+/// Check whether a character is an allowed address character
+/// All printable ASCII characters except for a few special characters are allowed
+fn is_address_character(x: char) -> bool {
+    match x {
+        ' ' | '#' | '*' | ',' | '/' | '?' | '[' | ']' | '{' | '}' => false,
+        c => c > '\x20' && c < '\x7F'
+    }
 }
 
 impl CharacterClass {
@@ -213,9 +218,9 @@ impl CharacterClass {
             // '!' besides at beginning has no special meaning, but is legal
             char::<_, nom::error::Error<&str>>('!').map(|_| String::from("")),
             // attempt to match a range like a-z or 0-9
-            separated_pair(satisfy(is_alphanumeric_char), char('-'), satisfy(is_alphanumeric_char)).map(|(first, second)| expand_character_range(first, second)),
+            separated_pair(satisfy(is_address_character), char('-'), satisfy(is_address_character)).map(|(first, second)| expand_character_range(first, second)),
             // Match characters literally
-            satisfy(is_alphanumeric_char).map(|x| x.to_string()),
+            satisfy(is_address_character).map(|x| x.to_string()),
             // Trailing dash
             char('-').map(|_| { String::from("-") })
         ))))(input);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@ extern crate std as core;
 
 extern crate nom;
 extern crate byteorder;
-#[cfg(feature = "std")]
-extern crate regex;
 
 /// Crate specific error types.
 mod errors;

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -114,8 +114,8 @@ fn test_matcher() {
     matcher.match_address("/oscillator/something/frequency").expect_err("Should not match");
 
     // Check for allowed literal characters
-    matcher = Matcher::new("/!\"$%&'()+-./0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~").expect("Should be valid");
-    matcher.match_address("/!\"$%&'()+-./0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~").expect("Should match");
+    matcher = Matcher::new("/!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~").expect("Should be valid");
+    matcher.match_address("/!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~").expect("Should match");
 }
 
 #[cfg(feature = "std")]

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -114,8 +114,8 @@ fn test_matcher() {
     matcher.match_address("/oscillator/something/frequency").expect_err("Should not match");
 
     // Check for allowed literal characters
-    matcher = Matcher::new("/[!-~]").expect("Should be valid");
-    matcher.match_address("/a").expect("Should match");
+    matcher = Matcher::new("/!\"$%&'()+-./0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~").expect("Should be valid");
+    matcher.match_address("/!\"$%&'()+-./0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~").expect("Should match");
 }
 
 #[cfg(feature = "std")]

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -177,6 +177,9 @@ fn test_verify_address_pattern() {
     // Unclosed range
     verify_address_pattern("/[a-/foo").expect_err("Should not be valid");
     verify_address_pattern("/[a-").expect_err("Should not be valid");
+    // Empty range
+    verify_address_pattern("/[]").expect_err("Should not be valid");
+    verify_address_pattern("/[!]").expect_err("Should not be valid");
     // Unclosed alternative
     verify_address_pattern("/{foo,bar/foo").expect_err("Should not be valid");
     verify_address_pattern("/{foo,/bar").expect_err("Should not be valid");

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -34,11 +34,11 @@ fn test_matcher() {
     assert_eq!(matcher.match_address("/oscillator/6").expect("Valid address pattern"), true);  // Middle of range
     assert_eq!(matcher.match_address("/oscillator/9").expect("Valid address pattern"), true);  // Last member of range included
 
-    // Inverted order should work too
+    // Inverted order should parse as correct pattern, but not match any characters
     matcher = Matcher::new("/oscillator/[9-0]").expect("Should be valid");
-    assert_eq!(matcher.match_address("/oscillator/0").expect("Valid address pattern"), true);
-    assert_eq!(matcher.match_address("/oscillator/6").expect("Valid address pattern"), true);
-    assert_eq!(matcher.match_address("/oscillator/9").expect("Valid address pattern"), true);
+    assert_eq!(matcher.match_address("/oscillator/0").expect("Valid address pattern"), false);
+    assert_eq!(matcher.match_address("/oscillator/6").expect("Valid address pattern"), false);
+    assert_eq!(matcher.match_address("/oscillator/9").expect("Valid address pattern"), false);
 
     // Multiple ranges
     matcher = Matcher::new("/oscillator/[a-zA-Z0-9]").expect("Should be valid");

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -117,6 +117,13 @@ fn test_matcher() {
     // Check for allowed literal characters
     matcher = Matcher::new("/!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~").expect("Should be valid");
     matcher.match_address("/!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~").expect("Should match");
+
+    // Check that single wildcard matches all legal characters
+    matcher = Matcher::new("/?").expect("Should be valid");
+    let legal = "!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~";
+    for c in legal.chars() {
+        matcher.match_address(format!("/{}", c).as_str()).expect("Should match");
+    }
 }
 
 #[cfg(feature = "std")]

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -175,6 +175,8 @@ fn test_verify_address_pattern() {
     verify_address_pattern("/test?").expect("Should be valid");
     verify_address_pattern("/test{foo,bar}").expect("Should be valid");
     verify_address_pattern("/test[a-z]").expect("Should be valid");
+    verify_address_pattern("/test[a-defgh]").expect("Should be valid");
+    verify_address_pattern("/test[a-defg-z]").expect("Should be valid");
     verify_address_pattern("/test[a-za-z]").expect("Should be valid");
     verify_address_pattern("/test[a-z]*??/{foo,bar,baz}[!a-z0-9]/*").expect("Should be valid");
     verify_address_pattern("/test{foo}").expect("Should be valid");
@@ -183,6 +185,10 @@ fn test_verify_address_pattern() {
     verify_address_pattern("/{asd,}/").expect_err("Should not be valid");
     // Illegal character in range
     verify_address_pattern("/[a-b*]/").expect_err("Should not be valid");
+    // Character range is reversed
+    verify_address_pattern("/[b-a]").expect_err("Should not be valid");
+    // Character range starting and ending at same character
+    verify_address_pattern("/[a-a]").expect_err("Should not be valid");
 
     // Empty
     verify_address_pattern("").expect_err("Should not be valid");

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -5,22 +5,113 @@ use rosc::address::Matcher;
 
 #[cfg(feature = "std")]
 #[test]
-fn test_matcher() {
-    let matcher = Matcher::new("/oscillator/[0-9]/*/pre[!1234?*]post/{frequency,phase}/x?")
-        .expect("Matcher::new");
-    assert_eq!(
-        matcher
-            .match_address("/oscillator/1/something/preXpost/phase/xy")
-            .expect("should match"),
-        true
-    );
-    assert_eq!(
-        matcher
-            .match_address("/oscillator/1/something/pre1post/phase/xy")
-            .expect("should not match"),
-        false
-    );
-    matcher.match_address("invalid_address").expect_err("should fail because address does not start with a slash");
+fn test_matcher_new() {
+    let mut matcher;
+
+    // Regular address using only alphanumeric parts
+    matcher = Matcher::new("/oscillator/1/frequency").expect("Should be valid");
+    matcher.match_address("/oscillator/1/frequency").expect("Should match");
+    matcher.match_address("/oscillator/1/phase").expect_err("Should not match");
+    matcher.match_address("/oscillator/1/frequencyfoo").expect_err("Should not match");
+    matcher.match_address("/prefix/oscillator/1/frequency").expect_err("Should not match");
+
+    // Choice
+    matcher = Matcher::new("/foo{bar,baz}").expect("Should be valid");
+    matcher.match_address("/foobar").expect("Should match");
+    matcher.match_address("/foobaz").expect("Should match");
+
+    matcher = Matcher::new("/foo{bar,baz,tron}").expect("Should be valid");
+    matcher.match_address("/footron").expect("Should match");
+
+    // Character class
+    // Character classes are sets or ranges of characters to match.
+    // e.g. [a-z] will match any lower case alphabetic character. [abcd] will match the characters abcd.
+    // They can be negated with '!', e.g. [!0-9] will match all characters except 0-9
+    // Basic example
+    matcher = Matcher::new("/oscillator/[0-9]").expect("Should be valid");
+    matcher.match_address("/oscillator/0").expect("Should match");  // Beginning of range included
+    matcher.match_address("/oscillator/6").expect("Should match");  // Middle of range
+    matcher.match_address("/oscillator/9").expect("Should match");  // Last member of range included
+
+    // Inverted order should work too
+    matcher = Matcher::new("/oscillator/[9-0]").expect("Should be valid");
+    matcher.match_address("/oscillator/0").expect("Should match");
+    matcher.match_address("/oscillator/6").expect("Should match");
+    matcher.match_address("/oscillator/9").expect("Should match");
+
+    // Multiple ranges
+    matcher = Matcher::new("/oscillator/[a-zA-Z0-9]").expect("Should be valid");
+    matcher.match_address("/oscillator/0").expect("Should match");
+    matcher.match_address("/oscillator/a").expect("Should match");
+    matcher.match_address("/oscillator/A").expect("Should match");
+
+    // Negated range
+    matcher = Matcher::new("/oscillator/[!0-9]").expect("Should be valid");
+    matcher.match_address("/oscillator/1").expect_err("Should not match");
+    matcher.match_address("/oscillator/a").expect("Should match");
+
+    // Extra exclamation points must be entirely ignored
+    matcher = Matcher::new("/oscillator/[!0-9!a-z!]").expect("Should be valid");
+    matcher.match_address("/oscillator/A").expect("Should match");
+
+    // Trailing dash has no special meaning
+    matcher = Matcher::new("/oscillator/[abcd-]").expect("Should be valid");
+    matcher.match_address("/oscillator/a").expect("Should match");
+    matcher.match_address("/oscillator/-").expect("Should match");
+
+    // Single wildcard
+    // A single wildcard '?' matches excatly one alphanumeric character
+    matcher = Matcher::new("/oscillator/?/frequency").expect("Should be valid");
+    matcher.match_address("/oscillator/1/frequency").expect("Should match");
+    matcher.match_address("/oscillator/F/frequency").expect("Should match");
+    matcher.match_address("/oscillator//frequency").expect_err("Should not match");
+    matcher.match_address("/oscillator/10/frequency").expect_err("Should not match");
+
+    // Test if two consecutive wildcards match
+    matcher = Matcher::new("/oscillator/??/frequency").expect("Should be valid");
+    matcher.match_address("/oscillator/10/frequency").expect("Should match");
+    matcher.match_address("/oscillator/1/frequency").expect_err("Should not match");
+
+    // Test if it works if it is surrounded by non-wildcards
+    matcher = Matcher::new("/oscillator/prefixed?postfixed/frequency").expect("Should be valid");
+    matcher.match_address("/oscillator/prefixed1postfixed/frequency").expect("Should match");
+    matcher.match_address("/oscillator/prefixedpostfixed/frequency").expect_err("Should not match");
+
+    // Wildcard
+    // Wildcards '*' match zero or more alphanumeric characters. The implementation is greedy,
+    // meaning it will match the longest possible sequence
+    matcher = Matcher::new("/oscillator/*/frequency").expect("Should be valid");
+    matcher.match_address("/oscillator/anything123/frequency").expect("Should match");
+    // Test that wildcard doesn't cross part boundary
+    matcher.match_address("/oscillator/extra/part/frequency").expect_err("Should not match");
+    matcher.match_address("/oscillator//frequency").expect_err("Should not match");
+
+    // Test greediness
+    matcher = Matcher::new("/oscillator/*bar/frequency").expect("Should be valid");
+    matcher.match_address("/oscillator/foobar/frequency").expect("Should match");
+    matcher.match_address("/oscillator/foobarbar/frequency").expect("Should match");
+
+    // Minimum length of 2
+    matcher = Matcher::new("/oscillator/*??/frequency").expect("Should be valid");
+    matcher.match_address("/oscillator/foobar/frequency").expect("Should match");
+    matcher.match_address("/oscillator/f/frequency").expect_err("Should not match");
+
+    // Minimum length of 2 and another component follows
+    matcher = Matcher::new("/oscillator/*??baz/frequency").expect("Should be valid");
+    matcher.match_address("/oscillator/foobarbaz/frequency").expect("Should match");
+    matcher.match_address("/oscillator/fbaz/frequency").expect_err("Should not match");
+
+    // Mix with character class
+    matcher = Matcher::new("/oscillator/*[a-d]/frequency").expect("Should be valid");
+    matcher.match_address("/oscillator/a/frequency").expect("Should match");
+    matcher.match_address("/oscillator/fooa/frequency").expect("Should match");
+    matcher.match_address("/oscillator/foox/frequency").expect_err("Should not match");
+
+    // Mix with choice
+    matcher = Matcher::new("/oscillator/*{bar,baz}/frequency").expect("Should be valid");
+    matcher.match_address("/oscillator/foobar/frequency").expect("Should match");
+    matcher.match_address("/oscillator/baz/frequency").expect("Should match");
+    matcher.match_address("/oscillator/something/frequency").expect_err("Should not match");
 }
 
 #[cfg(feature = "std")]

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -183,29 +183,3 @@ fn test_verify_address_pattern() {
     verify_address_pattern("/{foo").expect_err("Should not be valid");
     verify_address_pattern("/foo{,").expect_err("Should not be valid");
 }
-
-#[cfg(feature = "std")]
-#[test]
-fn test_bad_address_pattern() {
-    let expected_err = "bad OSC address pattern: bad address pattern";
-    assert_eq!(Matcher::new("").unwrap_err().to_string(), expected_err);
-    assert_eq!(Matcher::new("/").unwrap_err().to_string(), expected_err);
-    assert_eq!(Matcher::new("//empty/parts/").unwrap_err().to_string(), expected_err);
-    assert_eq!(Matcher::new("////").unwrap_err().to_string(), expected_err);
-    assert_eq!(Matcher::new("/{unclosed,alternative").unwrap_err().to_string(), expected_err);
-    assert_eq!(Matcher::new("/unclosed/[range-").unwrap_err().to_string(), expected_err);
-}
-
-#[cfg(feature = "std")]
-#[test]
-fn test_bad_address() {
-    let matcher = Matcher::new("/does-not-matter").expect("Matcher::new");
-    let expected_err = "bad OSC address: bad address";
-    assert_eq!(matcher.match_address("").unwrap_err().to_string(), expected_err);
-    assert_eq!(matcher.match_address("/").unwrap_err().to_string(), expected_err);
-    assert_eq!(matcher.match_address("/contains/wildcards?").unwrap_err().to_string(), expected_err);
-    assert_eq!(matcher.match_address("/contains/wildcards*").unwrap_err().to_string(), expected_err);
-    assert_eq!(matcher.match_address("/contains/ranges[a-z]").unwrap_err().to_string(), expected_err);
-    assert_eq!(matcher.match_address("/contains/ranges[!a-z]").unwrap_err().to_string(), expected_err);
-    assert_eq!(matcher.match_address("/{contains,alternative}").unwrap_err().to_string(), expected_err);
-}

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -1,7 +1,7 @@
 extern crate rosc;
 
 #[cfg(feature = "std")]
-use rosc::address::Matcher;
+use rosc::address::{Matcher, verify_address};
 
 #[cfg(feature = "std")]
 #[test]
@@ -124,6 +124,24 @@ fn test_matcher() {
     for c in legal.chars() {
         matcher.match_address(format!("/{}", c).as_str()).expect("Should match");
     }
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn test_verify_address() {
+    verify_address("/test").expect("Should be valid");
+    verify_address("/oscillator/1/frequency").expect("Should be valid");
+    verify_address("/!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~/foo").expect("Should be valid");
+
+    // No '/' at beginning
+    verify_address("test").expect_err("Should not be valid");
+    // '/' at the end
+    verify_address("/test/").expect_err("Should not be valid");
+    // Different address pattern elements that are not allowed in regular addresses
+    verify_address("/test*").expect_err("Should not be valid");
+    verify_address("/test?").expect_err("Should not be valid");
+    verify_address("/test{foo,bar}").expect_err("Should not be valid");
+    verify_address("/test[a-z]").expect_err("Should not be valid");
 }
 
 #[cfg(feature = "std")]

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -115,6 +115,15 @@ fn test_matcher() {
     assert_eq!(matcher.match_address("/oscillator/baz/frequency").expect("Valid address pattern"), true);
     assert_eq!(matcher.match_address("/oscillator/something/frequency").expect("Valid address pattern"), false);
 
+    // Wildcard as last part
+    matcher = Matcher::new("/oscillator/*").expect("Should be valid");
+    assert_eq!(matcher.match_address("/oscillator/foobar").expect("Valid address pattern"), true);
+    assert_eq!(matcher.match_address("/oscillator/foobar/frequency").expect("Valid address pattern"), false);
+
+    // Wildcard with more components in part but it's the last part
+    matcher = Matcher::new("/oscillator/*bar").expect("Should be valid");
+    assert_eq!(matcher.match_address("/oscillator/foobar").expect("Valid address pattern"), true);
+
     // Check for allowed literal characters
     matcher = Matcher::new("/!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~").expect("Should be valid");
     assert_eq!(matcher.match_address("/!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~").expect("Valid address pattern"), true);

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -82,6 +82,7 @@ fn test_matcher() {
     // meaning it will match the longest possible sequence
     matcher = Matcher::new("/oscillator/*/frequency").expect("Should be valid");
     matcher.match_address("/oscillator/anything123/frequency").expect("Should match");
+    matcher.match_address("/oscillator/!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~/frequency").expect("Should match");
     // Test that wildcard doesn't cross part boundary
     matcher.match_address("/oscillator/extra/part/frequency").expect_err("Should not match");
     matcher.match_address("/oscillator//frequency").expect_err("Should not match");

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -125,6 +125,10 @@ fn test_matcher() {
     for c in legal.chars() {
         assert_eq!(matcher.match_address(format!("/{}", c).as_str()).expect("Valid address pattern"), true);
     }
+
+    // Make sure the character class deduplicator is triggered for code coverage
+    matcher = Matcher::new("/[a-za-za-z]").expect("Should be valid");
+    assert_eq!(matcher.match_address("/a").expect("Valid address pattern"), true);
 }
 
 #[cfg(feature = "std")]
@@ -162,6 +166,7 @@ fn test_verify_address_pattern() {
     verify_address_pattern("/test?").expect("Should be valid");
     verify_address_pattern("/test{foo,bar}").expect("Should be valid");
     verify_address_pattern("/test[a-z]").expect("Should be valid");
+    verify_address_pattern("/test[a-za-z]").expect("Should be valid");
     verify_address_pattern("/test[a-z]*??/{foo,bar,baz}[!a-z0-9]/*").expect("Should be valid");
     verify_address_pattern("/test{foo}").expect("Should be valid");
 

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -5,7 +5,7 @@ use rosc::address::Matcher;
 
 #[cfg(feature = "std")]
 #[test]
-fn test_matcher_new() {
+fn test_matcher() {
     let mut matcher;
 
     // Regular address using only alphanumeric parts
@@ -112,6 +112,10 @@ fn test_matcher_new() {
     matcher.match_address("/oscillator/foobar/frequency").expect("Should match");
     matcher.match_address("/oscillator/baz/frequency").expect("Should match");
     matcher.match_address("/oscillator/something/frequency").expect_err("Should not match");
+
+    // Check for allowed literal characters
+    matcher = Matcher::new("/[!-~]").expect("Should be valid");
+    matcher.match_address("/a").expect("Should match");
 }
 
 #[cfg(feature = "std")]

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -169,6 +169,19 @@ fn test_verify_address_pattern() {
     verify_address_pattern("/{asd,}/").expect_err("Should not be valid");
     // Illegal character in range
     verify_address_pattern("/[a-b*]/").expect_err("Should not be valid");
+
+    // Empty
+    verify_address_pattern("").expect_err("Should not be valid");
+    // Empty part
+    verify_address_pattern("//empty/part").expect_err("Should not be valid");
+    // Unclosed range
+    verify_address_pattern("/[a-/foo").expect_err("Should not be valid");
+    verify_address_pattern("/[a-").expect_err("Should not be valid");
+    // Unclosed alternative
+    verify_address_pattern("/{foo,bar/foo").expect_err("Should not be valid");
+    verify_address_pattern("/{foo,/bar").expect_err("Should not be valid");
+    verify_address_pattern("/{foo").expect_err("Should not be valid");
+    verify_address_pattern("/foo{,").expect_err("Should not be valid");
 }
 
 #[cfg(feature = "std")]

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -2,6 +2,7 @@ extern crate rosc;
 
 #[cfg(feature = "std")]
 use rosc::address::{Matcher, verify_address};
+use rosc::address::verify_address_pattern;
 
 #[cfg(feature = "std")]
 #[test]
@@ -142,6 +143,32 @@ fn test_verify_address() {
     verify_address("/test?").expect_err("Should not be valid");
     verify_address("/test{foo,bar}").expect_err("Should not be valid");
     verify_address("/test[a-z]").expect_err("Should not be valid");
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn test_verify_address_pattern() {
+    verify_address_pattern("/test").expect("Should be valid");
+    verify_address_pattern("/oscillator/1/frequency").expect("Should be valid");
+    verify_address_pattern("/!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~/foo").expect("Should be valid");
+
+    // No '/' at beginning
+    verify_address_pattern("test").expect_err("Should not be valid");
+    // '/' at the end
+    verify_address_pattern("/test/").expect_err("Should not be valid");
+
+    // Different address pattern elements
+    verify_address_pattern("/test*").expect("Should be valid");
+    verify_address_pattern("/test?").expect("Should be valid");
+    verify_address_pattern("/test{foo,bar}").expect("Should be valid");
+    verify_address_pattern("/test[a-z]").expect("Should be valid");
+    verify_address_pattern("/test[a-z]*??/{foo,bar,baz}[!a-z0-9]/*").expect("Should be valid");
+    verify_address_pattern("/test{foo}").expect("Should be valid");
+
+    // Empty element in choice
+    verify_address_pattern("/{asd,}/").expect_err("Should not be valid");
+    // Illegal character in range
+    verify_address_pattern("/[a-b*]/").expect_err("Should not be valid");
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
This is my attempt at implementing a nom-based matcher to get rid of regex dependency as explained in #23.

It works by parsing the address pattern and separating it into `AddressPatternComponent`s. When matching, the matching method iterates over the components and applies the correct nom parser for each component, consuming the address to be matched part by part. If everything is consumed and every component parser was run, the match is successful, otherwise it's a failure.

 The one tricky thing to implement were wildcards in combination with other elements (e.g. `/foo/*{bar,baz}andsometext`). The wildcard parser was implemented to be greedy, so it tries to consume as many characters as possible.

This is still early WIP. The matcher is fully implemented, but everything around it needs work (documentation, removing unused functions, etc.), but I'd be happy about comments.