### PR TITLE
Apply clippy lints

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,11 @@ jobs:
       with:
         command: build
         args: --verbose
+    - name: Run cargo fmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --check
     - name: Run cargo test
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,29 +6,29 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v2
-    - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - name: Run cargo build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --verbose
-    - name: Run cargo fmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --check
-    - name: Run cargo test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --check
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose
   clippy_check:
     runs-on: ubuntu-latest
     steps:

--- a/src/address.rs
+++ b/src/address.rs
@@ -141,7 +141,7 @@ fn is_address_character(x: char) -> bool {
         return false
     }
 
-    return ![' ', '#', '*', ',', '/', '?', '[', ']', '{', '}'].contains(&x)
+    ![' ', '#', '*', ',', '/', '?', '[', ']', '{', '}'].contains(&x)
 }
 
 /// Parser to turn a choice like '{foo,bar}' into a vector containing the choices, like ["foo", "bar"]

--- a/src/address.rs
+++ b/src/address.rs
@@ -2,8 +2,7 @@ use crate::errors::OscError;
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use std::collections::HashSet;
-use std::iter::FromIterator;
+use core::fmt::{Display, Formatter};
 use nom::branch::alt;
 use nom::bytes::complete::{is_a, is_not, tag, take, take_while1, take_while_m_n};
 use nom::character::complete::{char, satisfy};
@@ -12,7 +11,8 @@ use nom::error::{ErrorKind, ParseError};
 use nom::multi::{many1, separated_list1};
 use nom::sequence::{delimited, pair, separated_pair};
 use nom::{IResult, Parser};
-use core::fmt::{Display, Formatter};
+use std::collections::HashSet;
+use std::iter::FromIterator;
 
 /// A valid OSC method address.
 ///
@@ -72,7 +72,8 @@ impl Matcher {
     pub fn new(pattern: &str) -> Result<Self, OscError> {
         verify_address_pattern(pattern)?;
         let mut match_fn = all_consuming(many1(map_address_pattern_component));
-        let (_, pattern_parts) = match_fn(pattern).map_err(|err| OscError::BadAddressPattern(err.to_string()))?;
+        let (_, pattern_parts) =
+            match_fn(pattern).map_err(|err| OscError::BadAddressPattern(err.to_string()))?;
 
         Ok(Matcher {
             pattern: pattern.into(),
@@ -138,7 +139,7 @@ impl Matcher {
 /// All printable ASCII characters except for a few special characters are allowed
 fn is_address_character(x: char) -> bool {
     if !x.is_ascii() || x.is_ascii_control() {
-        return false
+        return false;
     }
 
     ![' ', '#', '*', ',', '/', '?', '[', ']', '{', '}'].contains(&x)
@@ -171,7 +172,7 @@ fn pattern_character_class(input: &str) -> IResult<&str, &str> {
                 ),
                 // Need to map this into a tuple to make it compatible with the output of the
                 // separated pair parser above. Will always validate as true.
-                satisfy(is_address_character).map(|c| ('\0', c))
+                satisfy(is_address_character).map(|c| ('\0', c)),
             )),
             |(o1, o2): &(char, char)| o1 < o2,
         ))),
@@ -239,7 +240,9 @@ impl CharacterClass {
         match characters {
             Ok((_, o)) => CharacterClass {
                 negated,
-                characters: HashSet::<char>::from_iter(o.concat().chars()).iter().collect(),
+                characters: HashSet::<char>::from_iter(o.concat().chars())
+                    .iter()
+                    .collect(),
             },
             _ => {
                 panic!("Invalid character class formatting {}", s)

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,14 +1,19 @@
+use crate::alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use crate::errors::OscError;
-use crate::types::{OscArray, OscBundle, OscColor, OscMessage, OscMidiMessage, OscPacket, OscTime, OscType};
-use crate::alloc::{string::{String, ToString}, vec::Vec};
+use crate::types::{
+    OscArray, OscBundle, OscColor, OscMessage, OscMidiMessage, OscPacket, OscTime, OscType,
+};
 
-use nom::Offset;
-use nom::sequence::terminated;
 use nom::bytes::complete::{take, take_till};
 use nom::combinator::{map, map_parser};
 use nom::multi::many0;
 use nom::number::complete::{be_f32, be_f64, be_i32, be_i64, be_u32};
-use nom::{IResult,combinator::map_res,sequence::tuple,Err};
+use nom::sequence::terminated;
+use nom::Offset;
+use nom::{combinator::map_res, sequence::tuple, Err, IResult};
 
 /// Common MTU size for ethernet
 pub const MTU: usize = 1536;
@@ -21,7 +26,7 @@ pub fn decode_udp(msg: &[u8]) -> Result<(&[u8], OscPacket), OscError> {
         Err(e) => match e {
             Err::Incomplete(_) => Err(OscError::BadPacket("Incomplete data")),
             Err::Error(e) | Err::Failure(e) => Err(e),
-        }
+        },
     }
 }
 
@@ -33,21 +38,19 @@ pub fn decode_tcp(msg: &[u8]) -> Result<(&[u8], Option<OscPacket>), OscError> {
         Err(e) => match e {
             Err::Incomplete(_) => return Err(OscError::BadPacket("Incomplete data")),
             Err::Error(e) | Err::Failure(e) => return Err(e),
-        }
+        },
     };
 
     if osc_packet_length as usize > msg.len() {
         return Ok((msg, None));
     }
 
-    match decode_packet(input, msg).map(|(remainder, osc_packet)| {
-        (remainder, Some(osc_packet))
-    }) {
+    match decode_packet(input, msg).map(|(remainder, osc_packet)| (remainder, Some(osc_packet))) {
         Ok((remainder, osc_packet)) => Ok((remainder, osc_packet)),
         Err(e) => match e {
             Err::Incomplete(_) => Err(OscError::BadPacket("Incomplete data")),
             Err::Error(e) | Err::Failure(e) => Err(e),
-        }
+        },
     }
 }
 
@@ -61,18 +64,17 @@ pub fn decode_tcp_vec(msg: &[u8]) -> Result<(&[u8], Vec<OscPacket>), OscError> {
         input = remainder;
         osc_packets.push(osc_packet);
 
-        if remainder.len() == 0 {
+        if remainder.is_empty() {
             break;
         }
-    };
+    }
 
     Ok((input, osc_packets))
 }
 
-
 fn decode_packet<'a>(
     input: &'a [u8],
-    original_input: &'a[u8],
+    original_input: &'a [u8],
 ) -> IResult<&'a [u8], OscPacket, OscError> {
     if input.is_empty() {
         return Err(nom::Err::Error(OscError::BadPacket("Empty packet.")));
@@ -81,14 +83,10 @@ fn decode_packet<'a>(
     let (input, addr) = read_osc_string(input, original_input)?;
 
     match addr.chars().next() {
-        Some('/') => {
-            decode_message(addr, input, original_input)
-        }
-        Some('#') if &addr == "#bundle" => {
-            decode_bundle(input, original_input)
-        }
+        Some('/') => decode_message(addr, input, original_input),
+        Some('#') if &addr == "#bundle" => decode_bundle(input, original_input),
         _ => Err(nom::Err::Error(OscError::BadPacket(
-            "Invalid message address or bundle tag"
+            "Invalid message address or bundle tag",
         ))),
     }
 }
@@ -96,16 +94,12 @@ fn decode_packet<'a>(
 fn decode_message<'a>(
     addr: String,
     input: &'a [u8],
-    original_input: &'a[u8],
+    original_input: &'a [u8],
 ) -> IResult<&'a [u8], OscPacket, OscError> {
     let (input, type_tags) = read_osc_string(input, original_input)?;
 
     if type_tags.len() > 1 {
-        let (input, args) = read_osc_args(
-            input,
-            original_input,
-            type_tags,
-        )?;
+        let (input, args) = read_osc_args(input, original_input, type_tags)?;
         Ok((input, OscPacket::Message(OscMessage { addr, args })))
     } else {
         Ok((input, OscPacket::Message(OscMessage { addr, args: vec![] })))
@@ -114,23 +108,20 @@ fn decode_message<'a>(
 
 fn decode_bundle<'a>(
     input: &'a [u8],
-    original_input: &'a[u8],
+    original_input: &'a [u8],
 ) -> IResult<&'a [u8], OscPacket, OscError> {
     let (input, (timetag, content)) = tuple((
         read_time_tag,
         many0(|input| read_bundle_element(input, original_input)),
     ))(input)?;
 
-    Ok((
-        input,
-        OscPacket::Bundle(OscBundle {
-            timetag,
-            content,
-        }),
-    ))
+    Ok((input, OscPacket::Bundle(OscBundle { timetag, content })))
 }
 
-fn read_bundle_element<'a>(input: &'a [u8], original_input: &'a[u8]) -> IResult<&'a [u8], OscPacket, OscError> {
+fn read_bundle_element<'a>(
+    input: &'a [u8],
+    original_input: &'a [u8],
+) -> IResult<&'a [u8], OscPacket, OscError> {
     let (input, elem_size) = be_u32(input)?;
 
     let result = map_parser(
@@ -147,13 +138,16 @@ fn read_bundle_element<'a>(input: &'a [u8], original_input: &'a[u8]) -> IResult<
     result
 }
 
-fn read_osc_string<'a>(input: &'a [u8], original_input: &'a[u8]) -> IResult<&'a [u8], String, OscError> {
+fn read_osc_string<'a>(
+    input: &'a [u8],
+    original_input: &'a [u8],
+) -> IResult<&'a [u8], String, OscError> {
     map_res(
         terminated(
             take_till(|c| c == 0u8),
             pad_to_32_bit_boundary(original_input),
         ),
-        |str_buf: &'a[u8]| {
+        |str_buf: &'a [u8]| {
             String::from_utf8(str_buf.into())
                 .map_err(OscError::StringError)
                 .map(|s| s.trim_matches(0u8 as char).to_string())
@@ -162,10 +156,10 @@ fn read_osc_string<'a>(input: &'a [u8], original_input: &'a[u8]) -> IResult<&'a 
 }
 
 fn read_osc_args<'a>(
-    mut input: &'a[u8],
-    original_input: &'a[u8],
+    mut input: &'a [u8],
+    original_input: &'a [u8],
     raw_type_tags: String,
-) ->  IResult<&'a [u8], Vec<OscType>, OscError> {
+) -> IResult<&'a [u8], Vec<OscType>, OscError> {
     let type_tags: Vec<char> = raw_type_tags.chars().skip(1).collect();
 
     let mut args: Vec<OscType> = Vec::with_capacity(type_tags.len());
@@ -182,9 +176,11 @@ fn read_osc_args<'a>(
             let array = OscType::Array(OscArray { content: args });
             match stack.pop() {
                 Some(stashed) => args = stashed,
-                None => return Err(nom::Err::Error(OscError::BadMessage(
-                    "Encountered ] outside array"
-                ))),
+                None => {
+                    return Err(nom::Err::Error(OscError::BadMessage(
+                        "Encountered ] outside array",
+                    )))
+                }
             }
             args.push(array);
         } else {
@@ -196,19 +192,19 @@ fn read_osc_args<'a>(
     Ok((input, args))
 }
 
-fn read_osc_arg<'a>(input: &'a[u8], original_input: &'a[u8], tag: char) -> IResult<&'a[u8], OscType, OscError> {
+fn read_osc_arg<'a>(
+    input: &'a [u8],
+    original_input: &'a [u8],
+    tag: char,
+) -> IResult<&'a [u8], OscType, OscError> {
     match tag {
         'f' => map(be_f32, OscType::Float)(input),
         'd' => map(be_f64, OscType::Double)(input),
         'i' => map(be_i32, OscType::Int)(input),
         'h' => map(be_i64, OscType::Long)(input),
-        's' => {
-            read_osc_string(input, original_input)
-                .map(|(remainder, string)| (remainder, OscType::String(string)))
-        }
-        't' => read_time_tag(input).map(|(remainder, time)| {
-            (remainder, OscType::Time(time))
-        }),
+        's' => read_osc_string(input, original_input)
+            .map(|(remainder, string)| (remainder, OscType::String(string))),
+        't' => read_time_tag(input).map(|(remainder, time)| (remainder, OscType::Time(time))),
         'b' => read_blob(input, original_input),
         'r' => read_osc_color(input),
         'T' => Ok((input, true.into())),
@@ -225,28 +221,23 @@ fn read_osc_arg<'a>(input: &'a[u8], original_input: &'a[u8], tag: char) -> IResu
 }
 
 fn read_char(input: &[u8]) -> IResult<&[u8], OscType, OscError> {
-    map_res(
-        be_u32,
-        |b| {
-            let opt_char = char::from_u32(b);
-            match opt_char {
-                Some(c) => Ok(OscType::Char(c)),
-                None => Err(OscError::BadArg(
-                    "Argument is not a char!".to_string(),
-                )),
-            }
-        },
-    )(input)
+    map_res(be_u32, |b| {
+        let opt_char = char::from_u32(b);
+        match opt_char {
+            Some(c) => Ok(OscType::Char(c)),
+            None => Err(OscError::BadArg("Argument is not a char!".to_string())),
+        }
+    })(input)
 }
 
-fn read_blob<'a>(input: &'a[u8], original_input: &'a[u8]) -> IResult<&'a[u8], OscType, OscError> {
+fn read_blob<'a>(
+    input: &'a [u8],
+    original_input: &'a [u8],
+) -> IResult<&'a [u8], OscType, OscError> {
     let (input, size) = be_u32(input)?;
 
     map(
-        terminated(
-            take(size),
-            pad_to_32_bit_boundary(original_input),
-        ),
+        terminated(take(size), pad_to_32_bit_boundary(original_input)),
         |blob| OscType::Blob(blob.into()),
     )(input)
 }
@@ -281,8 +272,8 @@ fn read_osc_color(input: &[u8]) -> IResult<&[u8], OscType, OscError> {
 }
 
 fn pad_to_32_bit_boundary<'a>(
-    original_input: &'a[u8]
-) -> impl Fn(&'a[u8]) -> IResult<&'a[u8], (), OscError> {
+    original_input: &'a [u8],
+) -> impl Fn(&'a [u8]) -> IResult<&'a [u8], (), OscError> {
     move |input| {
         let offset = 4 - original_input.offset(input) % 4;
         let (input, _) = take(offset)(input)?;

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -15,7 +15,7 @@ pub const MTU: usize = 1536;
 
 /// Takes a bytes slice representing a UDP packet and returns the OSC packet as well as a slice of
 /// any bytes remaining after the OSC packet.
-pub fn decode_udp<'a>(msg: &'a [u8]) -> Result<(&'a [u8], OscPacket), OscError> {
+pub fn decode_udp(msg: &[u8]) -> Result<(&[u8], OscPacket), OscError> {
     match decode_packet(msg, msg) {
         Ok((remainder, osc_packet)) => Ok((remainder, osc_packet)),
         Err(e) => match e {
@@ -27,7 +27,7 @@ pub fn decode_udp<'a>(msg: &'a [u8]) -> Result<(&'a [u8], OscPacket), OscError> 
 
 /// Takes a bytes slice from a TCP stream (or any stream-based protocol) and returns the first OSC
 /// packet as well as a slice of the bytes remaining after the packet.
-pub fn decode_tcp<'a>(msg: &'a [u8]) -> Result<(&'a [u8], Option<OscPacket>), OscError> {
+pub fn decode_tcp(msg: &[u8]) -> Result<(&[u8], Option<OscPacket>), OscError> {
     let (input, osc_packet_length) = match be_u32(msg) {
         Ok((i, o)) => (i, o),
         Err(e) => match e {
@@ -53,7 +53,7 @@ pub fn decode_tcp<'a>(msg: &'a [u8]) -> Result<(&'a [u8], Option<OscPacket>), Os
 
 /// Takes a bytes slice from a TCP stream (or any stream-based protocol) and returns a vec of all
 /// OSC packets in the slice as well as a slice of the bytes remaining after the last packet.
-pub fn decode_tcp_vec<'a>(msg: &'a [u8]) -> Result<(&'a [u8], Vec<OscPacket>), OscError> {
+pub fn decode_tcp_vec(msg: &[u8]) -> Result<(&[u8], Vec<OscPacket>), OscError> {
     let mut input = msg;
     let mut osc_packets = vec![];
 
@@ -251,17 +251,14 @@ fn read_blob<'a>(input: &'a[u8], original_input: &'a[u8]) -> IResult<&'a[u8], Os
     )(input)
 }
 
-fn read_time_tag<'a>(input: &'a[u8]) -> IResult<&'a[u8], OscTime, OscError> {
-    map(
-        tuple((be_u32, be_u32)),
-        |(seconds, fractional)| OscTime {
-            seconds,
-            fractional,
-        },
-    )(input)
+fn read_time_tag(input: &[u8]) -> IResult<&[u8], OscTime, OscError> {
+    map(tuple((be_u32, be_u32)), |(seconds, fractional)| OscTime {
+        seconds,
+        fractional,
+    })(input)
 }
 
-fn read_midi_message<'a>(input: &'a[u8]) -> IResult<&'a[u8], OscType, OscError> {
+fn read_midi_message(input: &[u8]) -> IResult<&[u8], OscType, OscError> {
     map(take(4usize), |buf: &[u8]| {
         OscType::Midi(OscMidiMessage {
             port: buf[0],
@@ -272,7 +269,7 @@ fn read_midi_message<'a>(input: &'a[u8]) -> IResult<&'a[u8], OscType, OscError> 
     })(input)
 }
 
-fn read_osc_color<'a>(input: &'a[u8]) -> IResult<&'a[u8], OscType, OscError> {
+fn read_osc_color(input: &[u8]) -> IResult<&[u8], OscType, OscError> {
     map(take(4usize), |buf: &[u8]| {
         OscType::Color(OscColor {
             red: buf[0],

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,6 +1,9 @@
+use crate::alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use crate::errors::OscError;
 use crate::types::{OscBundle, OscMessage, OscPacket, OscTime, OscType, Result};
-use crate::alloc::{string::{ String, ToString }, vec::Vec};
 
 use byteorder::{BigEndian, ByteOrder};
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,10 @@
+use alloc::{
+    fmt,
+    string::{self, String},
+};
+use nom::error::{ErrorKind, FromExternalError, ParseError};
 #[cfg(feature = "std")]
 use std::error;
-use alloc::{fmt, string::{ self, String }};
-use nom::error::{ErrorKind, FromExternalError, ParseError};
 
 /// Represents errors returned by `decode` or `encode`.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,17 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]
-#[macro_use] extern crate alloc;
+#[macro_use]
+extern crate alloc;
 
 #[cfg(feature = "std")]
 extern crate std as core;
 #[cfg(feature = "std")]
-#[macro_use] extern crate std as alloc;
+#[macro_use]
+extern crate std as alloc;
 
-extern crate nom;
 extern crate byteorder;
+extern crate nom;
 
 /// Crate specific error types.
 mod errors;
@@ -22,10 +24,10 @@ mod types;
 pub use crate::errors::*;
 pub use crate::types::*;
 
+/// Address checking and matching methods
+#[cfg(feature = "std")]
+pub mod address;
 /// Provides a decoding method for OSC packets.
 pub mod decoder;
 /// Encodes an `OscPacket` to a byte vector.
 pub mod encoder;
-/// Address checking and matching methods
-#[cfg(feature = "std")]
-pub mod address;

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,9 +4,15 @@ use core::fmt::{self, Display};
 use core::{iter::FromIterator, result};
 
 #[cfg(feature = "std")]
-use std::{convert::{TryFrom, TryInto}, time::{Duration, SystemTime, UNIX_EPOCH}};
+use std::{
+    convert::{TryFrom, TryInto},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
-use crate::alloc::{string::{ String, ToString }, vec::Vec};
+use crate::alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 
 /// A time tag in OSC message consists of two 32-bit integers where the first one denotes the number of seconds since 1900-01-01 and the second the fractions of a second.
 /// For details on its semantics see http://opensoundcontrol.org/node/3/#timetags

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -1,8 +1,8 @@
 extern crate rosc;
 
 #[cfg(feature = "std")]
-use rosc::address::{Matcher, verify_address};
-use rosc::address::{OscAddress, verify_address_pattern};
+use rosc::address::{verify_address, Matcher};
+use rosc::address::{verify_address_pattern, OscAddress};
 
 #[cfg(feature = "std")]
 #[test]
@@ -11,18 +11,56 @@ fn test_matcher() {
 
     // Regular address using only alphanumeric parts
     matcher = Matcher::new("/oscillator/1/frequency").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/1/frequency")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/1/phase")).expect("Valid address pattern")), false);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/1/frequencyfoo")).expect("Valid address pattern")), false);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/prefix/oscillator/1/frequency")).expect("Valid address pattern")), false);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/1/frequency"))
+                .expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/1/phase")).expect("Valid address pattern")
+        ),
+        false
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/1/frequencyfoo"))
+                .expect("Valid address pattern")
+        ),
+        false
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/prefix/oscillator/1/frequency"))
+                .expect("Valid address pattern")
+        ),
+        false
+    );
 
     // Choice
     matcher = Matcher::new("/foo{bar,baz}").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/foobar")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/foobaz")).expect("Valid address pattern")), true);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/foobar")).expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/foobaz")).expect("Valid address pattern")
+        ),
+        true
+    );
 
     matcher = Matcher::new("/foo{bar,baz,tron}").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/footron")).expect("Valid address pattern")), true);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/footron")).expect("Valid address pattern")
+        ),
+        true
+    );
 
     // Character class
     // Character classes are sets or ranges of characters to match.
@@ -30,109 +68,317 @@ fn test_matcher() {
     // They can be negated with '!', e.g. [!0-9] will match all characters except 0-9
     // Basic example
     matcher = Matcher::new("/oscillator/[0-9]").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/0")).expect("Valid address pattern")), true);  // Beginning of range included
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/6")).expect("Valid address pattern")), true);  // Middle of range
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/9")).expect("Valid address pattern")), true);  // Last member of range included
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/0")).expect("Valid address pattern")
+        ),
+        true
+    ); // Beginning of range included
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/6")).expect("Valid address pattern")
+        ),
+        true
+    ); // Middle of range
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/9")).expect("Valid address pattern")
+        ),
+        true
+    ); // Last member of range included
 
     // Inverted order should fail
     Matcher::new("/oscillator/[9-0]").expect_err("Inverted range accepted");
 
     // Multiple ranges
     matcher = Matcher::new("/oscillator/[a-zA-Z0-9]").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/0")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/a")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/A")).expect("Valid address pattern")), true);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/0")).expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/a")).expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/A")).expect("Valid address pattern")
+        ),
+        true
+    );
 
     // Negated range
     matcher = Matcher::new("/oscillator/[!0-9]").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/1")).expect("Valid address pattern")), false);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/a")).expect("Valid address pattern")), true);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/1")).expect("Valid address pattern")
+        ),
+        false
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/a")).expect("Valid address pattern")
+        ),
+        true
+    );
 
     // Extra exclamation points must be entirely ignored
     matcher = Matcher::new("/oscillator/[!0-9!a-z!]").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/A")).expect("Valid address pattern")), true);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/A")).expect("Valid address pattern")
+        ),
+        true
+    );
 
     // Trailing dash has no special meaning
     matcher = Matcher::new("/oscillator/[abcd-]").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/a")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/-")).expect("Valid address pattern")), true);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/a")).expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/-")).expect("Valid address pattern")
+        ),
+        true
+    );
 
     // Single wildcard
     // A single wildcard '?' matches excatly one alphanumeric character
     matcher = Matcher::new("/oscillator/?/frequency").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/1/frequency")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/F/frequency")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/10/frequency")).expect("Valid address pattern")), false);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/1/frequency"))
+                .expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/F/frequency"))
+                .expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/10/frequency"))
+                .expect("Valid address pattern")
+        ),
+        false
+    );
 
     // Test if two consecutive wildcards match
     matcher = Matcher::new("/oscillator/??/frequency").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/10/frequency")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/1/frequency")).expect("Valid address pattern")), false);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/10/frequency"))
+                .expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/1/frequency"))
+                .expect("Valid address pattern")
+        ),
+        false
+    );
 
     // Test if it works if it is surrounded by non-wildcards
     matcher = Matcher::new("/oscillator/prefixed?postfixed/frequency").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/prefixed1postfixed/frequency")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/prefixedpostfixed/frequency")).expect("Valid address pattern")), false);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/prefixed1postfixed/frequency"))
+                .expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/prefixedpostfixed/frequency"))
+                .expect("Valid address pattern")
+        ),
+        false
+    );
 
     // Wildcard
     // Wildcards '*' match zero or more alphanumeric characters. The implementation is greedy,
     // meaning it will match the longest possible sequence
     matcher = Matcher::new("/oscillator/*/frequency").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/anything123/frequency")).expect("Valid address pattern")), true);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/anything123/frequency"))
+                .expect("Valid address pattern")
+        ),
+        true
+    );
     assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~/frequency")).expect("Valid address pattern")), true);
     // Test that wildcard doesn't cross part boundary
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/extra/part/frequency")).expect("Valid address pattern")), false);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/extra/part/frequency"))
+                .expect("Valid address pattern")
+        ),
+        false
+    );
 
     // Test greediness
     matcher = Matcher::new("/oscillator/*bar/frequency").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/foobar/frequency")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/foobarbar/frequency")).expect("Valid address pattern")), true);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/foobar/frequency"))
+                .expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/foobarbar/frequency"))
+                .expect("Valid address pattern")
+        ),
+        true
+    );
 
     // Minimum length of 2
     matcher = Matcher::new("/oscillator/*??/frequency").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/foobar/frequency")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/f/frequency")).expect("Valid address pattern")), false);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/foobar/frequency"))
+                .expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/f/frequency"))
+                .expect("Valid address pattern")
+        ),
+        false
+    );
 
     // Minimum length of 2 and another component follows
     matcher = Matcher::new("/oscillator/*??baz/frequency").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/foobarbaz/frequency")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/fbaz/frequency")).expect("Valid address pattern")), false);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/foobarbaz/frequency"))
+                .expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/fbaz/frequency"))
+                .expect("Valid address pattern")
+        ),
+        false
+    );
 
     // Mix with character class
     matcher = Matcher::new("/oscillator/*[a-d]/frequency").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/a/frequency")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/fooa/frequency")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/foox/frequency")).expect("Valid address pattern")), false);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/a/frequency"))
+                .expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/fooa/frequency"))
+                .expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/foox/frequency"))
+                .expect("Valid address pattern")
+        ),
+        false
+    );
 
     // Mix with choice
     matcher = Matcher::new("/oscillator/*{bar,baz}/frequency").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/foobar/frequency")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/baz/frequency")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/something/frequency")).expect("Valid address pattern")), false);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/foobar/frequency"))
+                .expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/baz/frequency"))
+                .expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/something/frequency"))
+                .expect("Valid address pattern")
+        ),
+        false
+    );
 
     // Wildcard as last part
     matcher = Matcher::new("/oscillator/*").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/foobar")).expect("Valid address pattern")), true);
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/foobar/frequency")).expect("Valid address pattern")), false);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/foobar")).expect("Valid address pattern")
+        ),
+        true
+    );
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/foobar/frequency"))
+                .expect("Valid address pattern")
+        ),
+        false
+    );
 
     // Wildcard with more components in part but it's the last part
     matcher = Matcher::new("/oscillator/*bar").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/oscillator/foobar")).expect("Valid address pattern")), true);
+    assert_eq!(
+        matcher.match_address(
+            &OscAddress::new(String::from("/oscillator/foobar")).expect("Valid address pattern")
+        ),
+        true
+    );
 
     // Check for allowed literal characters
-    matcher = Matcher::new("/!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~").expect("Should be valid");
+    matcher = Matcher::new(
+        "/!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~",
+    )
+    .expect("Should be valid");
     assert_eq!(matcher.match_address(&OscAddress::new(String::from("/!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~")).expect("Valid address pattern")), true);
 
     // Check that single wildcard matches all legal characters
     matcher = Matcher::new("/?").expect("Should be valid");
-    let legal = "!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~";
+    let legal =
+        "!\"$%&'()+-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~";
     for c in legal.chars() {
-        assert_eq!(matcher.match_address(&OscAddress::new(format!("/{}", c)).expect("Valid address pattern")), true);
+        assert_eq!(
+            matcher
+                .match_address(&OscAddress::new(format!("/{}", c)).expect("Valid address pattern")),
+            true
+        );
     }
 
     // Make sure the character class deduplicator is triggered for code coverage
     matcher = Matcher::new("/[a-za-za-z]").expect("Should be valid");
-    assert_eq!(matcher.match_address(&OscAddress::new(String::from("/a")).expect("Valid address pattern")), true);
+    assert_eq!(
+        matcher.match_address(&OscAddress::new(String::from("/a")).expect("Valid address pattern")),
+        true
+    );
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
This applies a couple of clippy lints.  It also adds a CI step that checks if the files were formatted using `cargo fmt`.  This formatting was also applied to the source code.