### PR TITLE
Refactored `Matcher.match_address` to use `PeekableIterator` instead of manual indexing.

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -101,20 +101,18 @@ impl Matcher {
         }
         let mut remainder: &str = address.0.as_str();
         // Match the the address component by component
-        for (index, part) in self.pattern_parts.iter().enumerate() {
+        let mut iter = self.pattern_parts.iter().peekable();
+        while let Some(part) = iter.next() {
             let result = match part {
                 AddressPatternComponent::Tag(s) => match_literally(remainder, s.as_str()),
                 AddressPatternComponent::WildcardSingle => match_wildcard_single(remainder),
                 AddressPatternComponent::Wildcard(l) => {
                     // Check if this is the last pattern component
-                    let next_part = self
-                        .pattern_parts
-                        .get(index + 1)
-                        .and_then(|part| match part {
-                            // If the next component is a '/', there are no more components in the current part and it can be wholly consumed
-                            AddressPatternComponent::Tag(s) if s == "/" => None,
-                            _ => Some(part),
-                        });
+                    let next_part = iter.peek().and_then(|&part| match part {
+                        // If the next component is a '/', there are no more components in the current part and it can be wholly consumed
+                        AddressPatternComponent::Tag(s) if s == "/" => None,
+                        _ => Some(part),
+                    });
                     match_wildcard(remainder, *l, next_part)
                 }
                 AddressPatternComponent::CharacterClass(cc) => match_character_class(remainder, cc),

--- a/src/address.rs
+++ b/src/address.rs
@@ -104,10 +104,10 @@ impl Matcher {
         let mut iter = self.pattern_parts.iter().peekable();
 
         while !remainder.is_empty() && let Some(part) = iter.next() {
-            let next = iter.peek().map(|&i| i);
+            let next = iter.peek().copied();
             // Match the the address component by component
             let result = match part {
-                AddressPatternComponent::Tag(s) => match_literally(remainder, &s),
+                AddressPatternComponent::Tag(s) => match_literally(remainder, s),
                 AddressPatternComponent::WildcardSingle => match_wildcard_single(remainder),
                 AddressPatternComponent::Wildcard(l) => match_wildcard(remainder, *l, next),
                 AddressPatternComponent::CharacterClass(cc) => match_character_class(remainder, cc),

--- a/src/address.rs
+++ b/src/address.rs
@@ -103,12 +103,14 @@ impl Matcher {
         let mut remainder = address.0.as_str();
         let mut iter = self.pattern_parts.iter().peekable();
 
-        while !remainder.is_empty() && let Some(part) = iter.next() {
+        while let Some(part) = iter.next() {
             // Match the the address component by component
             let result = match part {
                 AddressPatternComponent::Tag(s) => match_literally(remainder, s),
                 AddressPatternComponent::WildcardSingle => match_wildcard_single(remainder),
-                AddressPatternComponent::Wildcard(l) => match_wildcard(remainder, *l, iter.peek().copied()),
+                AddressPatternComponent::Wildcard(l) => {
+                    match_wildcard(remainder, *l, iter.peek().copied())
+                }
                 AddressPatternComponent::CharacterClass(cc) => match_character_class(remainder, cc),
                 AddressPatternComponent::Choice(s) => match_choice(remainder, s),
             };

--- a/src/address.rs
+++ b/src/address.rs
@@ -104,12 +104,11 @@ impl Matcher {
         let mut iter = self.pattern_parts.iter().peekable();
 
         while !remainder.is_empty() && let Some(part) = iter.next() {
-            let next = iter.peek().copied();
             // Match the the address component by component
             let result = match part {
                 AddressPatternComponent::Tag(s) => match_literally(remainder, s),
                 AddressPatternComponent::WildcardSingle => match_wildcard_single(remainder),
-                AddressPatternComponent::Wildcard(l) => match_wildcard(remainder, *l, next),
+                AddressPatternComponent::Wildcard(l) => match_wildcard(remainder, *l, iter.peek().copied()),
                 AddressPatternComponent::CharacterClass(cc) => match_character_class(remainder, cc),
                 AddressPatternComponent::Choice(s) => match_choice(remainder, s),
             };

--- a/src/address.rs
+++ b/src/address.rs
@@ -113,12 +113,10 @@ impl Matcher {
                 AddressPatternComponent::Choice(s) => match_choice(remainder, s),
             };
 
-            if let Ok((i, _)) = result {
-                remainder = i;
-            } else {
-                // Only carry on if the component matches.
-                return false;
-            }
+            remainder = match result {
+                Ok((i, _)) => i,
+                Err(_) => return false, // Component didn't match, goodbye
+            };
         }
 
         // Address is only matched if it was consumed entirely


### PR DESCRIPTION
Fixes https://github.com/klingtnet/rosc/issues/28

That being said, the removal of `mut remainder` in favor of a proper fold operation means the loss of one interesting property: the shortcut return when the `match_*` function returns an error. This changeset means `self.pattern_parts` is always fully iterated over (although the performance loss is probably negligible, unless the matcher's own pattern is *huge*).

In addition, if you look through the history of this pull request, my personal opinion is that the second-last revision (the one right before I get rid of the for loop and `mut remainder`) reads better.