### PR TITLE
Improved Encoder API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://docs.rs/rosc"
 repository = "https://github.com/klingtnet/rosc"
 license = "MIT/Apache-2.0"
 readme = "README.md"
+rust-version = "1.52"
 
 [features]
 lints = ["clippy"]

--- a/benches/encoder_bench.rs
+++ b/benches/encoder_bench.rs
@@ -1,0 +1,448 @@
+#![feature(test)]
+extern crate rosc;
+extern crate test;
+
+use self::test::Bencher;
+use rosc::*;
+
+#[bench]
+fn bench_encode_args_array(b: &mut Bencher) {
+    // Encoded message contains 100 argumnts, each of which is an Array containing 0-20 Int values.
+    let packet = OscPacket::Message(OscMessage {
+        addr: "/OSC/Array".into(),
+        args: (0..100)
+            .into_iter()
+            .map(|i| {
+                OscArray {
+                    content: (0..i % 20).into_iter().map(OscType::from).collect(),
+                }
+                .into()
+            })
+            .collect(),
+    });
+
+    b.iter(|| rosc::encoder::encode(&packet).unwrap());
+}
+
+#[bench]
+fn bench_encode_args_blob(b: &mut Bencher) {
+    // Encoded message contains 1000 argumnts, each of which is a Blob containing 0-20 bytes.
+    let packet = OscPacket::Message(OscMessage {
+        addr: "/OSC/Blobs".into(),
+        args: (0..1000)
+            .into_iter()
+            .map(|x| OscType::Blob((0..(x % 20) as u8).into_iter().collect()))
+            .collect(),
+    });
+
+    b.iter(|| rosc::encoder::encode(&packet).unwrap());
+}
+
+#[bench]
+fn bench_encode_args_bool(b: &mut Bencher) {
+    // Encoded message contains 1000 arguments, each of which is a Bool. Half are false and half are
+    // true.
+    let packet = OscPacket::Message(OscMessage {
+        addr: "/OSC/Bools".into(),
+        args: (0..1000)
+            .into_iter()
+            .map(|x| OscType::Bool((x % 2) == 1))
+            .collect(),
+    });
+
+    b.iter(|| rosc::encoder::encode(&packet).unwrap());
+}
+
+#[bench]
+fn bench_encode_args_double(b: &mut Bencher) {
+    // Encoded message contains 1000 arguments, each of which is a Double.
+    let packet = OscPacket::Message(OscMessage {
+        addr: "/OSC/Doubles".into(),
+        args: (0..1000)
+            .into_iter()
+            .map(|x| OscType::Double(x as f64))
+            .collect(),
+    });
+
+    b.iter(|| rosc::encoder::encode(&packet).unwrap());
+}
+
+#[bench]
+fn bench_encode_args_float(b: &mut Bencher) {
+    // Encoded message contains 1000 arguments, each of which is a Float.
+    let packet = OscPacket::Message(OscMessage {
+        addr: "/OSC/Floats".into(),
+        args: (0..1000)
+            .into_iter()
+            .map(|x| OscType::Float(x as f32))
+            .collect(),
+    });
+
+    b.iter(|| rosc::encoder::encode(&packet).unwrap());
+}
+
+#[bench]
+fn bench_encode_args_int(b: &mut Bencher) {
+    // Encoded message contains 1000 arguments, each of which is an Int.
+    let packet = OscPacket::Message(OscMessage {
+        addr: "/OSC/Ints".into(),
+        args: (0..1000).into_iter().map(OscType::Int).collect(),
+    });
+
+    b.iter(|| rosc::encoder::encode(&packet).unwrap());
+}
+
+#[bench]
+fn bench_encode_args_long(b: &mut Bencher) {
+    // Encoded message contains 1000 arguments, each of which is a Long.
+    let packet = OscPacket::Message(OscMessage {
+        addr: "/OSC/Longs".into(),
+        args: (0..1000).into_iter().map(OscType::Long).collect(),
+    });
+
+    b.iter(|| rosc::encoder::encode(&packet).unwrap());
+}
+
+#[bench]
+fn bench_encode_args_nil(b: &mut Bencher) {
+    // Encoded message contains 1000 arguments, each of which is Nil.
+    let packet = OscPacket::Message(OscMessage {
+        addr: "/OSC/Nils".into(),
+        args: (0..1000).into_iter().map(|_| OscType::Nil).collect(),
+    });
+
+    b.iter(|| rosc::encoder::encode(&packet).unwrap());
+}
+
+#[bench]
+fn bench_encode_args_string(b: &mut Bencher) {
+    // Encoded message contains 1000 arguments, each of which is a String containing the string
+    // representation of its argument index.
+    let packet = OscPacket::Message(OscMessage {
+        addr: "/OSC/Strings".into(),
+        args: (0..1000)
+            .into_iter()
+            .map(|x| OscType::String(x.to_string()))
+            .collect(),
+    });
+
+    b.iter(|| rosc::encoder::encode(&packet).unwrap());
+}
+
+#[bench]
+fn bench_encode_bundles(b: &mut Bencher) {
+    // Encoded bundle contains 1000 sub-bundles, each of which are empty.
+    let packet = OscPacket::Bundle(OscBundle {
+        timetag: (0, 0).into(),
+        content: vec![
+            OscPacket::Bundle(OscBundle {
+                timetag: (0, 0).into(),
+                content: vec![],
+            });
+            1000
+        ],
+    });
+
+    b.iter(|| rosc::encoder::encode(&packet).unwrap());
+}
+
+#[bench]
+fn bench_encode_bundles_into_new_vec(b: &mut Bencher) {
+    // Encoded bundle contains 1000 sub-bundles, each of which are empty.
+    // The packet is encoded into a new Vec each time, resulting in a fresh allocation.
+    let packet = OscPacket::Bundle(OscBundle {
+        timetag: (0, 0).into(),
+        content: vec![
+            OscPacket::Bundle(OscBundle {
+                timetag: (0, 0).into(),
+                content: vec![],
+            });
+            1000
+        ],
+    });
+
+    b.iter(|| rosc::encoder::encode_into(&packet, &mut Vec::new()).unwrap());
+}
+
+#[bench]
+fn bench_encode_bundles_into_reused_vec(b: &mut Bencher) {
+    // Encoded bundle contains 1000 sub-bundles, each of which are empty.
+    // The packet is encoded into the same Vec each time, resulting in no allocation after the first.
+    let packet = OscPacket::Bundle(OscBundle {
+        timetag: (0, 0).into(),
+        content: vec![
+            OscPacket::Bundle(OscBundle {
+                timetag: (0, 0).into(),
+                content: vec![],
+            });
+            1000
+        ],
+    });
+
+    let mut buffer = Vec::new();
+    b.iter(|| {
+        buffer.clear();
+        rosc::encoder::encode_into(&packet, &mut buffer).unwrap()
+    });
+}
+
+#[bench]
+fn bench_encode_huge_bundle(b: &mut Bencher) {
+    // Encoded bundle contains 1000 messages, each of which contains an argument of every type
+    // (including a 1 KB blob).
+    let packet = OscPacket::Bundle(OscBundle {
+        timetag: (0, 0).into(),
+        content: vec![
+            OscPacket::Message(OscMessage {
+                addr: "/OSC/Message".into(),
+                args: vec![
+                    4i32.into(),
+                    42i64.into(),
+                    3.1415926f32.into(),
+                    3.14159265359f64.into(),
+                    "String".into(),
+                    (0..1024)
+                        .into_iter()
+                        .map(|x| x as u8)
+                        .collect::<Vec<u8>>()
+                        .into(),
+                    (123, 456).into(),
+                    'c'.into(),
+                    false.into(),
+                    true.into(),
+                    OscType::Nil,
+                    OscType::Inf,
+                    OscMidiMessage {
+                        port: 4,
+                        status: 41,
+                        data1: 42,
+                        data2: 129,
+                    }
+                    .into(),
+                    OscColor {
+                        red: 255,
+                        green: 192,
+                        blue: 42,
+                        alpha: 13,
+                    }
+                    .into(),
+                    OscArray {
+                        content: vec![
+                            42i32.into(),
+                            OscArray {
+                                content: vec![1.23.into(), 3.21.into()],
+                            }
+                            .into(),
+                            "Another String".into(),
+                        ],
+                    }
+                    .into(),
+                ],
+            });
+            1000
+        ],
+    });
+
+    b.iter(|| rosc::encoder::encode(&packet).unwrap());
+}
+
+#[bench]
+fn bench_encode_huge_bundle_into_new_vec(b: &mut Bencher) {
+    // Encoded bundle contains 1000 messages, each of which contains an argument of every type
+    // (including a 1 KB blob).
+    // The packet is encoded into a new Vec each time, resulting in a fresh allocation.
+    let packet = OscPacket::Bundle(OscBundle {
+        timetag: (0, 0).into(),
+        content: vec![
+            OscPacket::Message(OscMessage {
+                addr: "/OSC/Message".into(),
+                args: vec![
+                    4i32.into(),
+                    42i64.into(),
+                    3.1415926f32.into(),
+                    3.14159265359f64.into(),
+                    "String".into(),
+                    (0..1024)
+                        .into_iter()
+                        .map(|x| x as u8)
+                        .collect::<Vec<u8>>()
+                        .into(),
+                    (123, 456).into(),
+                    'c'.into(),
+                    false.into(),
+                    true.into(),
+                    OscType::Nil,
+                    OscType::Inf,
+                    OscMidiMessage {
+                        port: 4,
+                        status: 41,
+                        data1: 42,
+                        data2: 129,
+                    }
+                    .into(),
+                    OscColor {
+                        red: 255,
+                        green: 192,
+                        blue: 42,
+                        alpha: 13,
+                    }
+                    .into(),
+                    OscArray {
+                        content: vec![
+                            42i32.into(),
+                            OscArray {
+                                content: vec![1.23.into(), 3.21.into()],
+                            }
+                            .into(),
+                            "Another String".into(),
+                        ],
+                    }
+                    .into(),
+                ],
+            });
+            1000
+        ],
+    });
+
+    b.iter(|| rosc::encoder::encode_into(&packet, &mut Vec::new()).unwrap());
+}
+
+#[bench]
+fn bench_encode_huge_bundle_into_reused_vec(b: &mut Bencher) {
+    // Encoded bundle contains 1000 messages, each of which contains an argument of every type
+    // (including a 1 KB blob).
+    // The packet is encoded into the same Vec each time, resulting in no allocation after the first.
+    let packet = OscPacket::Bundle(OscBundle {
+        timetag: (0, 0).into(),
+        content: vec![
+            OscPacket::Message(OscMessage {
+                addr: "/OSC/Message".into(),
+                args: vec![
+                    4i32.into(),
+                    42i64.into(),
+                    3.1415926f32.into(),
+                    3.14159265359f64.into(),
+                    "String".into(),
+                    (0..1024)
+                        .into_iter()
+                        .map(|x| x as u8)
+                        .collect::<Vec<u8>>()
+                        .into(),
+                    (123, 456).into(),
+                    'c'.into(),
+                    false.into(),
+                    true.into(),
+                    OscType::Nil,
+                    OscType::Inf,
+                    OscMidiMessage {
+                        port: 4,
+                        status: 41,
+                        data1: 42,
+                        data2: 129,
+                    }
+                    .into(),
+                    OscColor {
+                        red: 255,
+                        green: 192,
+                        blue: 42,
+                        alpha: 13,
+                    }
+                    .into(),
+                    OscArray {
+                        content: vec![
+                            42i32.into(),
+                            OscArray {
+                                content: vec![1.23.into(), 3.21.into()],
+                            }
+                            .into(),
+                            "Another String".into(),
+                        ],
+                    }
+                    .into(),
+                ],
+            });
+            1000
+        ],
+    });
+
+    let mut buffer = Vec::new();
+    b.iter(|| {
+        buffer.clear();
+        rosc::encoder::encode_into(&packet, &mut buffer).unwrap()
+    });
+}
+
+#[bench]
+fn bench_encode_messages(b: &mut Bencher) {
+    // Encoded bundle contains 1000 messages, each of which has no arguments.
+    let packet = OscPacket::Bundle(OscBundle {
+        timetag: (0, 0).into(),
+        content: vec![
+            OscPacket::Message(OscMessage {
+                addr: "/OSC/Message".into(),
+                args: vec![],
+            });
+            1000
+        ],
+    });
+
+    b.iter(|| rosc::encoder::encode(&packet).unwrap());
+}
+
+#[bench]
+fn bench_encode_messages_into_new_vec(b: &mut Bencher) {
+    // Encoded bundle contains 1000 messages, each of which has no arguments.
+    // The packet is encoded into a new Vec each time, resulting in a fresh allocation.
+    let packet = OscPacket::Bundle(OscBundle {
+        timetag: (0, 0).into(),
+        content: vec![
+            OscPacket::Message(OscMessage {
+                addr: "/OSC/Message".into(),
+                args: vec![],
+            });
+            1000
+        ],
+    });
+
+    b.iter(|| rosc::encoder::encode_into(&packet, &mut Vec::new()).unwrap());
+}
+
+#[bench]
+fn bench_encode_messages_into_reused_vec(b: &mut Bencher) {
+    // Encoded bundle contains 1000 messages, each of which has no arguments.
+    // The packet is encoded into the same Vec each time, resulting in no allocation after the first.
+    let packet = OscPacket::Bundle(OscBundle {
+        timetag: (0, 0).into(),
+        content: vec![
+            OscPacket::Message(OscMessage {
+                addr: "/OSC/Message".into(),
+                args: vec![],
+            });
+            1000
+        ],
+    });
+
+    let mut buffer = Vec::new();
+    b.iter(|| {
+        buffer.clear();
+        rosc::encoder::encode_into(&packet, &mut buffer).unwrap()
+    });
+}
+
+#[bench]
+fn bench_encode_nested_bundles(b: &mut Bencher) {
+    // Encoded bundle contains 1000 sub-bundles, each of which are empty.
+    let mut packet = OscPacket::Message(OscMessage {
+        addr: "/OSC/Nssted".into(),
+        args: vec![],
+    });
+
+    for _ in 0..20 {
+        packet = OscPacket::Bundle(OscBundle {
+            timetag: (0, 0).into(),
+            content: vec![packet],
+        });
+    }
+
+    b.iter(|| rosc::encoder::encode(&packet).unwrap());
+}

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,11 +1,5 @@
-use crate::alloc::{
-    string::{String, ToString},
-    vec::Vec,
-};
-use crate::errors::OscError;
-use crate::types::{OscBundle, OscMessage, OscPacket, OscTime, OscType, Result};
-
-use byteorder::{BigEndian, ByteOrder};
+use crate::alloc::{string::String, vec::Vec};
+use crate::types::{OscBundle, OscMessage, OscPacket, OscTime, OscType};
 
 /// Takes a reference to an OSC packet and returns
 /// a byte vector on success. If the packet was invalid
@@ -24,140 +18,155 @@ use byteorder::{BigEndian, ByteOrder};
 /// );
 /// assert!(encoder::encode(&packet).is_ok())
 /// ```
-pub fn encode(packet: &OscPacket) -> Result<Vec<u8>> {
+pub fn encode(packet: &OscPacket) -> crate::types::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+
+    // NOTE: The Output implementation for Vec<u8> can't actually produce an error!
+    encode_into(packet, &mut bytes).expect("Failed to write encoded packet into Vec");
+
+    Ok(bytes)
+}
+
+/// Takes a reference to an OSC packet and writes the
+/// encoded bytes to the given output. On success, the
+/// number of bytes written will be returned. If an error
+/// occurs during encoding, encoding will stop and the
+/// error will be returned. Note that in that case, the
+/// output may have been partially written!
+///
+/// NOTE: The OSC encoder will write output in small pieces
+/// (as small as a single byte), so the output should be
+/// buffered if write calls have a large overhead (e.g.
+/// writing to a file).
+///
+/// # Example
+///
+/// ```
+/// use rosc::{OscPacket,OscMessage,OscType};
+/// use rosc::encoder;
+///
+/// let mut bytes = Vec::new();
+/// let packet = OscPacket::Message(OscMessage{
+///         addr: "/greet/me".to_string(),
+///         args: vec![OscType::String("hi!".to_string())]
+///     }
+/// );
+/// assert!(encoder::encode_into(&packet, &mut bytes).is_ok())
+/// ```
+pub fn encode_into<O: Output>(packet: &OscPacket, out: &mut O) -> Result<usize, O::Err> {
     match *packet {
-        OscPacket::Message(ref msg) => encode_message(msg),
-        OscPacket::Bundle(ref bundle) => encode_bundle(bundle),
+        OscPacket::Message(ref msg) => encode_message(msg, out),
+        OscPacket::Bundle(ref bundle) => encode_bundle(bundle, out),
     }
 }
 
-fn encode_message(msg: &OscMessage) -> Result<Vec<u8>> {
-    let mut msg_bytes: Vec<u8> = Vec::new();
+fn encode_message<O: Output>(msg: &OscMessage, out: &mut O) -> Result<usize, O::Err> {
+    let mut written = encode_string_into(&msg.addr, out)?;
 
-    msg_bytes.extend(encode_string(msg.addr.clone()));
-    let mut type_tags: Vec<char> = vec![','];
-    let mut arg_bytes: Vec<u8> = Vec::new();
+    written += out.write(b",")?;
+    for arg in &msg.args {
+        written += encode_arg_type(arg, out)?;
+    }
+
+    let padding = pad(written as u64 + 1) as usize - written;
+    written += out.write(&[0u8; 4][..padding])?;
 
     for arg in &msg.args {
-        let (bytes, tags): (Option<Vec<u8>>, String) = encode_arg(arg)?;
-
-        type_tags.extend(tags.chars());
-        if let Some(data) = bytes {
-            arg_bytes.extend(data);
-        }
+        written += encode_arg_data(arg, out)?;
     }
 
-    msg_bytes.extend(encode_string(type_tags.into_iter().collect::<String>()));
-    if !arg_bytes.is_empty() {
-        msg_bytes.extend(arg_bytes);
-    }
-    Ok(msg_bytes)
+    Ok(written)
 }
 
-fn encode_bundle(bundle: &OscBundle) -> Result<Vec<u8>> {
-    let mut bundle_bytes: Vec<u8> = Vec::new();
-    bundle_bytes.extend(encode_string("#bundle".to_string()).into_iter());
-
-    match encode_arg(&OscType::Time(bundle.timetag))? {
-        (Some(x), _) => {
-            bundle_bytes.extend(x.into_iter());
-        }
-        (None, _) => {
-            return Err(OscError::BadBundle("Missing time tag!".to_string()));
-        }
-    }
-
-    if bundle.content.is_empty() {
-        return Ok(bundle_bytes);
-    }
+fn encode_bundle<O: Output>(bundle: &OscBundle, out: &mut O) -> Result<usize, O::Err> {
+    let mut written = encode_string_into("#bundle", out)?;
+    written += encode_time_tag_into(&bundle.timetag, out)?;
 
     for packet in &bundle.content {
         match *packet {
             OscPacket::Message(ref m) => {
-                let msg = encode_message(m)?;
-                let mut msg_size = vec![0u8; 4];
-                BigEndian::write_u32(&mut msg_size, msg.len() as u32);
-                bundle_bytes.extend(msg_size.into_iter().chain(msg.into_iter()));
+                let length_mark = out.mark(4)?;
+
+                let length = encode_message(m, out)?;
+                out.place(length_mark, &(length as u32).to_be_bytes())?;
+
+                written += 4 + length;
             }
             OscPacket::Bundle(ref b) => {
-                let bdl = encode_bundle(b)?;
-                let mut bdl_size = vec![0u8; 4];
-                BigEndian::write_u32(&mut bdl_size, bdl.len() as u32);
-                bundle_bytes.extend(bdl_size.into_iter().chain(bdl.into_iter()));
+                let length_mark = out.mark(4)?;
+
+                let length = encode_bundle(b, out)?;
+                out.place(length_mark, &(length as u32).to_be_bytes())?;
+
+                written += 4 + length;
             }
         }
     }
 
-    Ok(bundle_bytes)
+    Ok(written)
 }
 
-fn encode_arg(arg: &OscType) -> Result<(Option<Vec<u8>>, String)> {
+fn encode_arg_data<O: Output>(arg: &OscType, out: &mut O) -> Result<usize, O::Err> {
     match *arg {
-        OscType::Int(ref x) => {
-            let mut bytes = vec![0u8; 4];
-            BigEndian::write_i32(&mut bytes, *x);
-            Ok((Some(bytes), "i".into()))
-        }
-        OscType::Long(ref x) => {
-            let mut bytes = vec![0u8; 8];
-            BigEndian::write_i64(&mut bytes, *x);
-            Ok((Some(bytes), "h".into()))
-        }
-        OscType::Float(ref x) => {
-            let mut bytes = vec![0u8; 4];
-            BigEndian::write_f32(&mut bytes, *x);
-            Ok((Some(bytes), "f".into()))
-        }
-        OscType::Double(ref x) => {
-            let mut bytes = vec![0u8; 8];
-            BigEndian::write_f64(&mut bytes, *x);
-            Ok((Some(bytes), "d".into()))
-        }
-        OscType::Char(ref x) => {
-            let mut bytes = vec![0u8; 4];
-            BigEndian::write_u32(&mut bytes, *x as u32);
-            Ok((Some(bytes), "c".into()))
-        }
-        OscType::String(ref x) => Ok((Some(encode_string(x.clone())), "s".into())),
+        OscType::Int(x) => out.write(&x.to_be_bytes()),
+        OscType::Long(x) => out.write(&x.to_be_bytes()),
+        OscType::Float(x) => out.write(&x.to_be_bytes()),
+        OscType::Double(x) => out.write(&x.to_be_bytes()),
+        OscType::Char(x) => out.write(&(x as u32).to_be_bytes()),
+        OscType::String(ref x) => encode_string_into(x, out),
         OscType::Blob(ref x) => {
-            let padded_blob_length: usize = pad(x.len() as u64) as usize;
-            let mut bytes = vec![0u8; 4 + padded_blob_length];
-            // write length
-            BigEndian::write_i32(&mut bytes[..4], x.len() as i32);
-            for (i, v) in x.iter().enumerate() {
-                bytes[i + 4] = *v;
+            let padded_blob_length = pad(x.len() as u64) as usize;
+            let padding = padded_blob_length - x.len();
+
+            out.write(&(x.len() as u32).to_be_bytes())?;
+            out.write(x)?;
+
+            if padding > 0 {
+                out.write(&[0u8; 3][..padding])?;
             }
-            Ok((Some(bytes), "b".into()))
+
+            Ok(4 + padded_blob_length)
         }
-        OscType::Time(time) => Ok((Some(encode_time_tag(time)), "t".into())),
-        OscType::Midi(ref x) => Ok((Some(vec![x.port, x.status, x.data1, x.data2]), "m".into())),
-        OscType::Color(ref x) => Ok((Some(vec![x.red, x.green, x.blue, x.alpha]), "r".into())),
-        OscType::Bool(ref x) => {
-            if *x {
-                Ok((None, "T".into()))
-            } else {
-                Ok((None, "F".into()))
-            }
-        }
-        OscType::Nil => Ok((None, "N".into())),
-        OscType::Inf => Ok((None, "I".into())),
+        OscType::Time(ref time) => encode_time_tag_into(time, out),
+        OscType::Midi(ref x) => out.write(&[x.port, x.status, x.data1, x.data2]),
+        OscType::Color(ref x) => out.write(&[x.red, x.green, x.blue, x.alpha]),
+        OscType::Bool(_) => Ok(0),
+        OscType::Nil => Ok(0),
+        OscType::Inf => Ok(0),
         OscType::Array(ref x) => {
-            let mut bytes = vec![0u8; 0];
-            let mut type_tags = String::from("[");
-            for v in x.content.iter() {
-                match encode_arg(v) {
-                    Ok((Some(other_bytes), other_type_tags)) => {
-                        bytes.extend(other_bytes);
-                        type_tags.push_str(&other_type_tags);
-                    }
-                    Ok((None, other_type_tags)) => {
-                        type_tags.push_str(&other_type_tags);
-                    }
-                    Err(err) => return Err(err),
-                }
+            let mut written = 0;
+            for v in &x.content {
+                written += encode_arg_data(v, out)?;
             }
-            type_tags.push(']');
-            Ok((Some(bytes), type_tags))
+            Ok(written)
+        }
+    }
+}
+
+fn encode_arg_type<O: Output>(arg: &OscType, out: &mut O) -> Result<usize, O::Err> {
+    match *arg {
+        OscType::Int(_) => out.write(b"i"),
+        OscType::Long(_) => out.write(b"h"),
+        OscType::Float(_) => out.write(b"f"),
+        OscType::Double(_) => out.write(b"d"),
+        OscType::Char(_) => out.write(b"c"),
+        OscType::String(_) => out.write(b"s"),
+        OscType::Blob(_) => out.write(b"b"),
+        OscType::Time(_) => out.write(b"t"),
+        OscType::Midi(_) => out.write(b"m"),
+        OscType::Color(_) => out.write(b"r"),
+        OscType::Bool(x) => out.write(if x { b"T" } else { b"F" }),
+        OscType::Nil => out.write(b"N"),
+        OscType::Inf => out.write(b"I"),
+        OscType::Array(ref x) => {
+            let mut written = out.write(b"[")?;
+
+            for v in &x.content {
+                written += encode_arg_type(v, out)?;
+            }
+
+            written += out.write(b"]")?;
+            Ok(written)
         }
     }
 }
@@ -166,17 +175,25 @@ fn encode_arg(arg: &OscType) -> Result<(Option<Vec<u8>>, String)> {
 /// adds null bytes until the length of the result is a
 /// multiple of 4.
 pub fn encode_string<S: Into<String>>(s: S) -> Vec<u8> {
-    let mut bytes: Vec<u8> = s.into().as_bytes().into();
-    bytes.push(0u8);
-    pad_bytes(&mut bytes);
+    let mut bytes: Vec<u8> = s.into().into_bytes();
+
+    let new_len = pad(bytes.len() as u64 + 1) as usize;
+    bytes.resize(new_len, 0u8);
+
     bytes
 }
 
-fn pad_bytes(bytes: &mut Vec<u8>) {
-    let padded_lengh = pad(bytes.len() as u64);
-    while bytes.len() < padded_lengh as usize {
-        bytes.push(0u8)
-    }
+/// Writes the given string `s` to the given Output, adding
+/// 1-4 null bytes such that the length of the result is a
+/// multiple of 4.
+pub fn encode_string_into<S: AsRef<str>, O: Output>(s: S, out: &mut O) -> Result<usize, O::Err> {
+    let s = s.as_ref();
+
+    let padded_len = pad(s.len() as u64 + 1) as usize;
+    let padding = padded_len - s.len();
+    out.write(s.as_bytes())?;
+    out.write(&[0u8; 4][..padding])?;
+    Ok(s.len() + padding)
 }
 
 /// Returns the position padded to 4 bytes.
@@ -196,11 +213,10 @@ pub fn pad(pos: u64) -> u64 {
     }
 }
 
-fn encode_time_tag(time: OscTime) -> Vec<u8> {
-    let mut bytes = vec![0u8; 8];
-    BigEndian::write_u32(&mut bytes[..4], time.seconds);
-    BigEndian::write_u32(&mut bytes[4..], time.fractional);
-    bytes
+fn encode_time_tag_into<O: Output>(time: &OscTime, out: &mut O) -> Result<usize, O::Err> {
+    out.write(&time.seconds.to_be_bytes())?;
+    out.write(&time.fractional.to_be_bytes())?;
+    Ok(8)
 }
 
 #[test]
@@ -209,4 +225,106 @@ fn test_pad() {
     assert_eq!(8, pad(5));
     assert_eq!(8, pad(6));
     assert_eq!(8, pad(7));
+}
+
+/// A trait for values that can receive encoded OSC output
+/// via `encode_into`. This allows more flexibility in how
+/// the output is handled, including reusing part of an
+/// existing buffer or writing directly to an external sink
+/// (e.g. a file).
+///
+/// Implementations are currently provided for this trait for:
+/// - `Vec<u8>`: Data will be appended to the end of the Vec.
+/// - `WriteOutput<W>` (with feature `std`): A wrapper that
+///   allows data to be written to any type that implements
+///   `std::io::Seek + std::io::Write`.
+pub trait Output {
+    /// The error type which is returned from Output functions.
+    type Err;
+
+    /// The type which should be used to indicate the location of a mark.
+    type Mark;
+
+    /// Writes a block of data to the output.
+    ///
+    /// Note that, unlike `std::io::Writo::write`, this
+    /// function is expected to write all of the given data prior to returning.
+    fn write(&mut self, data: &[u8]) -> Result<usize, Self::Err>;
+
+    /// Marks the location of a fixed-length value and returns a `Self::Mark` which may be used to
+    /// fill in its data later with `place`.
+    fn mark(&mut self, size: usize) -> Result<Self::Mark, Self::Err>;
+
+    /// Consumes a previously-generated Mark and fills it in with data.
+    ///
+    /// This may result in a panic or in invalid data being written if `mark` came from a different
+    /// `Output`, or if the length of `data` does not match the size passed to `mark`.
+    fn place(&mut self, mark: Self::Mark, data: &[u8]) -> Result<(), Self::Err>;
+}
+
+impl Output for Vec<u8> {
+    type Err = core::convert::Infallible;
+    type Mark = (usize, usize);
+
+    #[inline]
+    fn mark(&mut self, size: usize) -> Result<Self::Mark, Self::Err> {
+        let start = self.len();
+        let end = start + size;
+
+        self.resize(end, 0);
+        Ok((start, end))
+    }
+
+    #[inline]
+    fn place(&mut self, (start, end): Self::Mark, data: &[u8]) -> Result<(), Self::Err> {
+        self[start..end].copy_from_slice(data);
+        Ok(())
+    }
+
+    #[inline]
+    fn write(&mut self, data: &[u8]) -> Result<usize, Self::Err> {
+        self.extend(data);
+        Ok(data.len())
+    }
+}
+
+/// A newtype which can be used to wrap any type which
+/// implements `std::io::Seek` and `std::io::Write` to allow
+/// it to be used as an `Output`.
+#[cfg(feature = "std")]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct WriteOutput<W>(pub W);
+
+#[cfg(feature = "std")]
+impl<W: std::io::Seek + std::io::Write> Output for WriteOutput<W> {
+    type Err = std::io::Error;
+    type Mark = u64;
+
+    fn mark(&mut self, size: usize) -> Result<Self::Mark, Self::Err> {
+        let pos = self.0.stream_position()?;
+
+        let mut left = size;
+        while left > 0 {
+            let num = left.min(8);
+            self.0.write_all(&[0; 8][..num])?;
+            left -= num;
+        }
+
+        Ok(pos)
+    }
+
+    fn place(&mut self, pos: Self::Mark, data: &[u8]) -> Result<(), Self::Err> {
+        let old_pos = self.0.stream_position()?;
+
+        self.0.seek(std::io::SeekFrom::Start(pos))?;
+        self.0.write_all(data)?;
+        self.0.seek(std::io::SeekFrom::Start(old_pos))?;
+
+        Ok(())
+    }
+
+    #[inline]
+    fn write(&mut self, data: &[u8]) -> Result<usize, Self::Err> {
+        std::io::Write::write_all(&mut self.0, data).map(|_| data.len())
+    }
 }

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -1,8 +1,7 @@
 extern crate rosc;
 
 #[cfg(feature = "std")]
-use rosc::address::{verify_address, Matcher};
-use rosc::address::{verify_address_pattern, OscAddress};
+use rosc::address::{verify_address, verify_address_pattern, Matcher, OscAddress};
 
 #[cfg(feature = "std")]
 #[test]


### PR DESCRIPTION
This PR reworks the implementation of the `encoder` module to accomplish 2 goals:

1. Improve the performance of the `encoder` logic. The existing implementation performs a *lot* of small allocations due to creating and passing around around small `Vec` and `String` objects internally. The reworked implementation passes through a reference to the output, and all data is written directly to the output; no internal buffers are allocated, making performance much faster. The performance improvement from this is significant, improving performance by 3-50x in my results from stress-test benchmarks that I created alongside these changes (sample results below). In a practical project in which I'm using `rosc`, these changes have decreased the amount of time spent encoding OSC packets to about 1/8 of what it was before (from ~150 us per packet to ~18 us) with no code changes in that project.

2. Make the output more flexible. This PR adds an `Output` trait which allows the user control over what is done with the output. `Output` is implemented for `Vec<u8>`, allowing for a packet to easily be encoded into a Vec. For `std`, there is also a `WriteOutput` newtype which allows any `std::io::Seek + std::io::Write` type to be used as an `Output`, allowing OSC data to be encoded directly to a `Cursor`, `File`, etc. These changes also include `encode_into` and `encode_string_into` functions, which allow the user to pass in a mutable reference to any object implementing this `Output` trait, allowing the user to control how the encoded data is handled.

The existing public functions have not had their signatures altered, only new public items have been added. Thus, according to the [SemVer Compatibility guide](https://doc.rust-lang.org/cargo/reference/semver.html), these changes should only qualify as a minor change. Additionally, these changes do not incur a MSRV bump (1.52 is the minimum supported version according to `cargo-msrv`, both with and without these changes). Thus, these changes don't require a major version bump.

This also fixes unit tests not building without the `std` feature. All existing unit tests are passing, both with and without `std`. No additional unit tests have been added.

Benchmark results on my machine for comparison:

| Benchmark                                | `master` (Windows) | `encoder-improvements` (Windows) | Relative Speed (Windows) | `master` (Linux)  | `encoder-improvements` (Linux) | Relative Speed (Linux) |
|------------------------------------------|--------------------|----------------------------------|--------------------------|-------------------|--------------------------------|------------------------|
| bench_encode_args_array                  | 90,150 ± 4,137     | 5,929 ± 51                       | 15.2x                    | 39,945 ± 615      | 4,610 ± 52                     | 8.7x                   |
| bench_encode_args_blob                   | 73,101 ± 989       | 8,940 ± 69                       | 8.2x                     | 32,807 ± 201      | 9,931 ± 85                     | 3.3x                   |
| bench_encode_args_bool                   | 37,263 ± 665       | 4,932 ± 107                      | 7.6x                     | 16,431 ± 179      | 4,846 ± 50                     | 3.4x                   |
| bench_encode_args_double                 | 69,613 ± 1,721     | 5,506 ± 39                       | 12.6x                    | 29,751 ± 131      | 5,366 ± 22                     | 5.5x                   |
| bench_encode_args_float                  | 69,645 ± 1,475     | 5,413 ± 22                       | 12.9x                    | 29,924 ± 336      | 4,974 ± 15                     | 6.0x                   |
| bench_encode_args_int                    | 70,911 ± 6,504     | 5,751 ± 43                       | 12.3x                    | 29,742 ± 280      | 4,264 ± 12                     | 7.0x                   |
| bench_encode_args_long                   | 70,653 ± 1,034     | 5,425 ± 46                       | 13.0x                    | 29,634 ± 88       | 5,064 ± 38                     | 5.9x                   |
| bench_encode_args_nil                    | 37,474 ± 918       | 4,983 ± 47                       | 7.5x                     | 16,188 ± 110      | 4,797 ± 18                     | 3.4x                   |
| bench_encode_args_string                 | 141,297 ± 2,025    | 9,083 ± 50                       | 13.9x                    | 46,884 ± 108      | 9,801 ± 34                     | 4.8x                   |
| bench_encode_bundles                     | 294,400 ± 23,868   | 5,844 ± 48                       | 50.4x                    | 99,883 ± 1,409    | 4,639 ± 16                     | 21.5x                  |
| bench_encode_bundles_into_new_vec        | -                  | 6,825 ± 70                       | -                        | -                 | 6,159 ± 281                    | -                      |
| bench_encode_bundles_into_reused_vec     | -                  | 5,282 ± 52                       | -                        | -                 | 6,152 ± 57                     | -                      |
| bench_encode_huge_bundle                 | 2,932,320 ± 91,668 | 562,780 ± 11,300                 | 5.2x                     | 1,270,594 ± 8,991 | 121,758 ± 1,017                | 10.4x                  |
| bench_encode_huge_bundle_into_new_vec    | -                  | 565,861 ± 13,714                 | -                        | -                 | 131,854 ± 862                  | -                      |
| bench_encode_huge_bundle_into_reused_vec | -                  | 137,702 ± 713                    | -                        | -                 | 132,321 ± 832                  | -                      |
| bench_encode_messages                    | 374,490 ± 3,665    | 10,903 ± 241                     | 34.3x                    | 135,246 ± 949     | 9,637 ± 41                     | 14.0x                  |
| bench_encode_messages_into_new_vec       | -                  | 11,988 ± 55                      | -                        | -                 | 11,539 ± 61                    | -                      |
| bench_encode_messages_into_reused_vec    | -                  | 10,386 ± 54                      | -                        | -                 | 11,355 ± 53                    | -                      |
| bench_encode_nested_bundles              | 8,009 ± 136        | 640 ± 25                         | 12.5x                    | 2,842 ± 25        | 240 ± 6                        | 11.8x                  |

I find the discrepancy between the `encode` benchmarks and the `into_new_vec` benchmarks interesting, because they should be doing almost the exact same thing, and yet the `encode` benchmark is noticeably faster in most cases (except for the `huge` benchmark).