### PR TITLE
Extend TCP decoding documentation

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -59,7 +59,7 @@ impl Matcher {
     /// - `{foo,bar}` is an alternative, matching either `foo` or `bar`
     /// - everything else is matched literally
     ///
-    /// Refer to the OSC specification for details about address pattern matching: <osc-message-dispatching-and-pattern-matching>.
+    /// Refer to the OSC specification for details about address pattern matching: <https://opensoundcontrol.stanford.edu/spec-1_0.html#osc-message-dispatching-and-pattern-matching>.
     ///
     /// # Examples
     ///

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -32,6 +32,15 @@ pub fn decode_udp(msg: &[u8]) -> Result<(&[u8], OscPacket), OscError> {
 
 /// Takes a bytes slice from a TCP stream (or any stream-based protocol) and returns the first OSC
 /// packet as well as a slice of the bytes remaining after the packet.
+///
+/// # Difference to `decode_udp`
+///
+/// For stream-based protocols, such as TCP, the [OSC specification][^1] requires the size of
+/// the first packet to be send as a 32-bit integer before the actual packet data.
+///
+/// [^1]: _In a stream-based protocol such as TCP, the stream should begin with an int32 giving the size of the first packet, followed by the contents of the first packet, followed by the size of the second packet, etc._
+///
+/// [OSC specification]: https://cnmat.org/OpenSoundControl/OSC-spec.html
 pub fn decode_tcp(msg: &[u8]) -> Result<(&[u8], Option<OscPacket>), OscError> {
     let (input, osc_packet_length) = match be_u32(msg) {
         Ok((i, o)) => (i, o),

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,7 +15,7 @@ use crate::alloc::{
 };
 
 /// A time tag in OSC message consists of two 32-bit integers where the first one denotes the number of seconds since 1900-01-01 and the second the fractions of a second.
-/// For details on its semantics see http://opensoundcontrol.org/node/3/#timetags
+/// For details on its semantics see <http://opensoundcontrol.org/node/3/#timetags>
 ///
 /// # Examples
 ///


### PR DESCRIPTION
This adds an explanation of the differences between UDP and TCP OSC message decoding to the doc string.  Additionally two doc warnings got fixed by either using proper link markup or by adding the actual link.

Closes #45.