### PR TITLE
Implement std::fmt::Display for all OSC types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ std = []
 byteorder = {version = "1", default-features = false}
 clippy = {version = "^0", optional = true}
 nom = {version = "7", default-features = false, features = ["alloc"]}
+time = { version = "0.3.9", default-features = false, features = ["formatting"] }
 
 [dev-dependencies]
 hex = {version = "0.4"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@ extern crate std as alloc;
 extern crate byteorder;
 extern crate nom;
 
+#[cfg(feature = "std")]
+extern crate time;
+
 /// Crate specific error types.
 mod errors;
 /// OSC data types, see [OSC 1.0 specification](https://opensoundcontrol.stanford.edu/spec-1_0.html) for details.


### PR DESCRIPTION
Implement the `std::fmt::Display` trait for `OscPacket`, `OscType`, and related types. This is to facilitate cleaner log output in consuming projects.

### OscType

Message argument values are prepended by the appropriate type tag as defined in the OSC 1.0 spec.

| Variant | Formatted Ouptut |
| ------------- | ------------- |
| `OscType::Int` | `(i) 123` |
| `OscType::Float` | `(f) 123.4` |
| `OscType::String` | `(s) abc` |
| `OscType::Blob` | `(b) 0x000102FF` |
| `OscType::Time` | `(t) 1970-01-01T00:00:00.000000000Z` |
| `OscType::Long` | `(h) 123` |
| `OscType::Double` | `(d) 123.4` |
| `OscType::Char` | `(c) a` |
| `OscType::Color` | `(r) {255,127,63,255}` |
| `OscType::Midi` | `(m) {port:3, status:0xF0, data:0x1234}` |
| `OscType::Bool` | `(T)` or `(F)` |
| `OscType::Array` | `[(i) 123,(f) 123.4,(s) abc]` |
| `OscType::Nil` | `(N)` |
| `OscType::Inf` | `(I)` |

### OscPacket (Message)

`/oscillator/1/frequency, (f) 123.4, (T)`

### OscPacket (Bundle)

`#bundle 1970-01-01T00:00:00.000000000Z { /oscillator/1/frequency, (f) 123.4, (T); /oscillator/2/frequency, (f) 246.8, (F); #bundle 1970-01-01T00:00:00.000000000Z { /oscillator/3/frequency, (f) 123.4, (T) } }`