### PR TITLE
added tcp examples and a tcp encoder function

### DIFF
--- a/examples/receiver_tcp.rs
+++ b/examples/receiver_tcp.rs
@@ -1,0 +1,97 @@
+extern crate rosc;
+
+use rosc::decoder::decode_tcp;
+use rosc::OscPacket;
+use std::env;
+use std::io::Read;
+use std::net::{SocketAddrV4, TcpListener, TcpStream};
+use std::str::FromStr;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let usage = format!("Usage {} [bind]|[conn] IP:PORT\n Use bind to open a local TCP socket at address, use conn to connect to the given addres", args[0]);
+    if args.len() < 3 {
+        println!("{}", usage);
+        ::std::process::exit(1)
+    }
+    println!("{:?}", args);
+    let addr = match SocketAddrV4::from_str(&args[2]) {
+        Ok(addr) => addr,
+        Err(_) => panic!("{}", usage),
+    };
+
+    if let Some(mut stream) = if args[1].as_str() == "bind" {
+        let listener = TcpListener::bind(addr).unwrap();
+        match listener.accept() {
+            Ok((stream, addr)) => {
+                println!("Connected to {}", addr);
+                Some(stream)
+            }
+            Err(e) => {
+                println!("Error accepting TCP: {}", e);
+                None
+            }
+        }
+    } else if args[1].as_str() == "conn" {
+        let stream = Some(TcpStream::connect(addr).unwrap());
+        println!("Connected to {}", addr);
+        stream
+    } else {
+        panic!("{}", usage);
+    } {
+        let mut buf = [0u8; rosc::decoder::MTU];
+
+        loop {
+            match stream.read(&mut buf) {
+                Ok(0) => {
+                    // End-Of-File
+                }
+                Ok(size) => {
+                    println!("Received packet with size {} from: {}", size, addr);
+
+                    let mut slice = &buf[0..size];
+
+                    while let Some(remainder) = match decode_tcp(slice) {
+                        Ok((remainder, None)) => {
+                            if remainder.is_empty() {
+                                None
+                            } else {
+                                Some(remainder)
+                            }
+                        }
+                        Ok((remainder, Some(packet))) => {
+                            handle_packet(packet);
+                            if remainder.is_empty() {
+                                None
+                            } else {
+                                Some(remainder)
+                            }
+                        }
+                        Err(e) => {
+                            println!("Error parsing OscPacket: {}", e);
+                            None
+                        }
+                    } {
+                        slice = remainder;
+                    }
+                }
+                Err(e) => {
+                    println!("Error reading TCP stream: {}", e);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn handle_packet(packet: OscPacket) {
+    match packet {
+        OscPacket::Message(msg) => {
+            println!("OSC address: {}", msg.addr);
+            println!("OSC arguments: {:?}", msg.args);
+        }
+        OscPacket::Bundle(bundle) => {
+            println!("OSC Bundle: {:?}", bundle);
+        }
+    }
+}

--- a/examples/sender_tcp.rs
+++ b/examples/sender_tcp.rs
@@ -1,0 +1,54 @@
+extern crate rosc;
+
+use rosc::encoder::{self, Output};
+use rosc::{OscMessage, OscPacket, OscType};
+use std::io::Write;
+use std::net::{SocketAddrV4, TcpStream};
+use std::str::FromStr;
+use std::time::Duration;
+use std::{env, f32, thread};
+
+fn get_addr_from_arg(arg: &str) -> SocketAddrV4 {
+    SocketAddrV4::from_str(arg).unwrap()
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let usage = format!("Usage: {} IP:PORT", &args[0]);
+    if args.len() < 2 {
+        panic!("{}", usage);
+    }
+    let addr = get_addr_from_arg(&args[1]);
+    let mut stream = TcpStream::connect(addr).unwrap();
+
+    // switch view
+    let msg_buf = encoder::encode_tcp(&OscPacket::Message(OscMessage {
+        addr: "/3".to_string(),
+        args: vec![],
+    }))
+    .unwrap();
+
+    stream.write_all(&msg_buf).unwrap();
+
+    // send random values to xy fields
+    let steps = 128;
+    let step_size: f32 = 2.0 * f32::consts::PI / steps as f32;
+    for i in 0.. {
+        let x = 0.5 + (step_size * (i % steps) as f32).sin() / 2.0;
+        let y = 0.5 + (step_size * (i % steps) as f32).cos() / 2.0;
+        let mut msg_buf = encoder::encode_tcp(&OscPacket::Message(OscMessage {
+            addr: "/3/xy1".to_string(),
+            args: vec![OscType::Float(x), OscType::Float(y)],
+        }))
+        .unwrap();
+
+        stream.write_all(&msg_buf).unwrap();
+        msg_buf = encoder::encode_tcp(&OscPacket::Message(OscMessage {
+            addr: "/3/xy2".to_string(),
+            args: vec![OscType::Float(y), OscType::Float(x)],
+        }))
+        .unwrap();
+        stream.write_all(&msg_buf).unwrap();
+        thread::sleep(Duration::from_millis(20));
+    }
+}


### PR DESCRIPTION
For my project which runs on embassy with the NCM usb driver I needed to send OSC messages over TCP, which would not work without adding the message length to the first 4 bytes of the packet. For completions sake I also added some tests and a sender and receiver example.