### PR TITLE
Fix for build failure with no_std

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup --version
       - run: cargo test
+      - run: cargo test --no-default-features
       - run: cargo build --release
       - run: cargo fmt --check
       - run: cargo clippy -- -Dclippy::all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ version = "0.11.3"
 [features]
 default = ["std"]
 lints = ["clippy"]
-std = []
+std = ["time"]
 
 [dependencies]
 byteorder = {version = "1", default-features = false}
 clippy = {version = "^0", optional = true}
 nom = {version = "7", default-features = false, features = ["alloc"]}
-time = { version = "0.3.9", default-features = false, features = ["formatting"] }
+time = { version = "0.3.9", default-features = false, features = ["formatting"], optional = true }
 
 [dev-dependencies]
 hex = {version = "0.4"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,12 @@ lints = ["clippy"]
 std = ["time"]
 
 [dependencies]
-byteorder = {version = "1", default-features = false}
-clippy = {version = "^0", optional = true}
-nom = {version = "7", default-features = false, features = ["alloc"]}
-time = { version = "0.3.9", default-features = false, features = ["formatting"], optional = true }
+byteorder = { version = "1", default-features = false }
+clippy = { version = "^0", optional = true }
+nom = { version = "7", default-features = false, features = ["alloc"] }
+time = { version = "0.3.9", default-features = false, features = [
+    "formatting",
+], optional = true }
 
 [dev-dependencies]
-hex = {version = "0.4"}
+hex = { version = "0.4" }

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 extern crate rosc;
 
 #[cfg(feature = "std")]

--- a/tests/decode_encode_test.rs
+++ b/tests/decode_encode_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 extern crate rosc;
 
 use rosc::{decoder, encoder};
@@ -10,6 +12,7 @@ const GOLDEN_MESSAGE_WITH_ALL_TYPES: &str = "2f616e6f746865722f616464726573732f3
 const GOLDEN_EMPTY_BUNDLE: &str = "2362756e646c65000000000400000002";
 const GOLDEN_BUNDLE: &str = "2362756e646c6500000004d2000010e10000000c2f766965772f31002c000000000000202f6d697865722f6368616e6e656c2f312f616d70000000002c6600003f666666000000442362756e646c65000000162e0000223d000000142f6f73632f312f66726571002c690000000001b8000000182f6f73632f312f7068617365000000002c660000becccccd";
 
+#[cfg(feature = "std")]
 #[test]
 fn test_message_wo_args() {
     let packet = OscPacket::Message(OscMessage {
@@ -24,6 +27,8 @@ fn test_message_wo_args() {
     assert_eq!(0, tail.len());
     assert_eq!(packet, decoded_packet)
 }
+
+#[cfg(feature = "std")]
 #[test]
 fn test_message_wo_args_tcp() {
     let packet = OscPacket::Message(OscMessage {
@@ -42,6 +47,7 @@ fn test_message_wo_args_tcp() {
     assert_eq!(Some(packet), decoded_packet)
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_encode_message_with_all_types() {
     let packet = OscPacket::Message(OscMessage {
@@ -95,6 +101,8 @@ fn test_encode_message_with_all_types() {
     assert_eq!(0, tail.len());
     assert_eq!(packet, decoded_packet)
 }
+
+#[cfg(feature = "std")]
 #[test]
 fn test_encode_message_with_all_types_tcp() {
     let packet = OscPacket::Message(OscMessage {
@@ -152,6 +160,8 @@ fn test_encode_message_with_all_types_tcp() {
     assert_eq!(0, tail.len());
     assert_eq!(Some(packet), decoded_packet)
 }
+
+#[cfg(feature = "std")]
 #[test]
 fn test_empty_bundle() {
     let packet = OscPacket::Bundle(OscBundle {
@@ -167,6 +177,7 @@ fn test_empty_bundle() {
     assert_eq!(packet, decoded_packet)
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_bundle() {
     let packet = OscPacket::Bundle(OscBundle {
@@ -244,6 +255,7 @@ fn test_bundle_cursor() {
     assert_eq!(hex::decode(GOLDEN_BUNDLE).unwrap(), bytes);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_decode_encoded_message_four_byte_aligned_blob() {
     let message = OscPacket::Message(OscMessage {
@@ -255,6 +267,7 @@ fn test_decode_encoded_message_four_byte_aligned_blob() {
     assert_eq!(message, decoded_packet)
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_decode_encoded_message_four_byte_aligned_blob_and_string() {
     let message = OscPacket::Message(OscMessage {

--- a/tests/types_test.rs
+++ b/tests/types_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 extern crate rosc;
 
 use rosc::{OscArray, OscType};
@@ -11,6 +13,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+#[cfg(feature = "std")]
 #[test]
 fn test_osc_array_from_iter() {
     use std::iter::FromIterator;


### PR DESCRIPTION
Fixed issue https://github.com/klingtnet/rosc/issues/59
Also run ‘cargo test -no-default-features’ in GitHub Actions to avoid regression.