### PR TITLE
fix MSRV to 1.67.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 name = "rosc"
 readme = "README.md"
 repository = "https://github.com/klingtnet/rosc"
-rust-version = "1.56"
+rust-version = "1.67.1"
 version = "0.11.3"
 
 [features]


### PR DESCRIPTION
The current `rust-version` is not correct. Probably due to the MSRV of the `time`crate.
The correct MSRV was found using [cargo-msrv](https://github.com/foresterre/cargo-msrv).

If you would like to try it out, you can check with the following command.

```sh
cargo msrv find
```

