### PR TITLE
Fix wildcard when matching nothing

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -4,7 +4,7 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::fmt::{Display, Formatter};
 use nom::branch::alt;
-use nom::bytes::complete::{is_a, is_not, tag, take, take_while1, take_while_m_n};
+use nom::bytes::complete::{is_a, is_not, tag, take, take_while, take_while1, take_while_m_n};
 use nom::character::complete::{char, satisfy};
 use nom::combinator::{all_consuming, complete, opt, recognize, verify};
 use nom::error::{ErrorKind, ParseError};
@@ -321,7 +321,7 @@ fn match_wildcard<'a>(
     });
     match next {
         // No next component, consume all allowed characters until end or next '/'
-        None => verify(take_while1(is_address_character), |s: &str| {
+        None => verify(take_while(is_address_character), |s: &str| {
             s.len() >= minimum_length
         })(input),
         // There is another element in this part, so logic gets a bit more complicated

--- a/tests/address_test.rs
+++ b/tests/address_test.rs
@@ -187,6 +187,20 @@ fn test_matcher() {
             .expect("Valid address pattern")
     ));
 
+    matcher = Matcher::new("/oscillator/[12345]*").expect("Should be valid");
+    assert!(matcher.match_address(
+        &OscAddress::new(String::from("/oscillator/12")).expect("Valid address pattern")
+    ));
+    assert!(matcher.match_address(
+        &OscAddress::new(String::from("/oscillator/2")).expect("Valid address pattern")
+    ));
+    assert!(!matcher.match_address(
+        &OscAddress::new(String::from("/oscillator/6")).expect("Valid address pattern")
+    ));
+    assert!(!matcher.match_address(
+        &OscAddress::new(String::from("/oscillator/60")).expect("Valid address pattern")
+    ));
+
     // Mix with choice
     matcher = Matcher::new("/oscillator/*{bar,baz}/frequency").expect("Should be valid");
     assert!(matcher.match_address(


### PR DESCRIPTION
According to the OSC standard, a wildcard (*) matches zero or more characters. But in the implementation it always had to match something. Now matching nothing is also valid.